### PR TITLE
Force building with static boost (like the pre-built versions)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ endif (WIN32)
 
 include_directories (${CMAKE_SOURCE_DIR})
 
+set(Boost_USE_STATIC_LIBS        ON)
+set(Boost_USE_MULTITHREADED      ON)
+set(Boost_USE_STATIC_RUNTIME     ON)
 find_package (Boost 1.57.0 REQUIRED COMPONENTS filesystem system log log_setup thread program_options regex chrono atomic)
 include_directories (${Boost_INCLUDE_DIR})
 


### PR DESCRIPTION
If you don't do that you need to specify -DBOOST_LOG_DYN_LINK or it won't link under linux