### PR TITLE
Fix build on linux i686

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ else (WIN32)
 	endif()
 endif (WIN32)
 
+set (PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -DCRYPTOPP_DISABLE_ASM")
+
 if (WIN32)
 	set (PLATFORM_C_FLAGS "/std=c11")
 else (WIN32)
@@ -268,7 +270,7 @@ add_executable (rai_node
 SET (ACTIVE_NETWORK rai_active_network CACHE STRING "Selects which network parameters are used")
 set_property (CACHE ACTIVE_NETWORK PROPERTY STRINGS rai_test_network rai_beta_network rai_live_network)
 
-set_target_properties (cryptopp PROPERTIES COMPILE_FLAGS "-DCRYPTOPP_DISABLE_ASM")
+set_target_properties (cryptopp PROPERTIES COMPILE_FLAGS "${PLATFORM_CXX_FLAGS} ${PLATFORM_COMPILE_FLAGS} -Wno-error=switch")
 set_target_properties (argon2 PROPERTIES COMPILE_FLAGS "${PLATFORM_CXX_FLAGS} ${PLATFORM_COMPILE_FLAGS}")
 set_target_properties (blake2 PROPERTIES COMPILE_FLAGS "${PLATFORM_C_FLAGS} ${PLATFORM_COMPILE_FLAGS} -D__SSE2__")
 set_target_properties (ed25519 PROPERTIES COMPILE_FLAGS "${PLATFORM_C_FLAGS} ${PLATFORM_COMPILE_FLAGS} -DED25519_CUSTOMHASH -DED25519_CUSTOMRNG")


### PR DESCRIPTION
CRYPTOPP_DISABLE_ASM should be defined for any targets since it's also
used in some includes files used by non-cryptopp targets