### PR TITLE
Status block

### DIFF
--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -622,6 +622,7 @@ void rai_qt::status::set_text ()
 {
 	wallet.status->setText (text ().c_str ());
 	wallet.status->setStyleSheet ((std::string ("QLabel {") + color () + "}").c_str ());
+    wallet.status->setToolTip("Wallet status and wallet block count (blocks remaining to sync)");
 }
 
 std::string rai_qt::status::text ()

--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -115,7 +115,7 @@ wallet (wallet_a)
 			this->wallet.change_rendering_ratio (rai::rai_ratio);
         }
     });
-	krai->click ();
+	mrai->click ();
 }
 
 void rai_qt::self_pane::refresh_balance ()

--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -642,12 +642,7 @@ std::string rai_qt::status::text ()
 			result = "Status: Generating proof of work";
 			break;
 		case rai_qt::status_types::synchronizing:
-			result = "Status: Synchronizing, Block: ";
-            if (unchecked != 0)
-            {
-                count_string += " (" + std::to_string (unchecked) + ")";
-            }
-            result += count_string.c_str ();
+			result = "Status: Synchronizing";
 			break;
 		case rai_qt::status_types::locked:
 			result = "Status: Wallet locked";
@@ -659,17 +654,20 @@ std::string rai_qt::status::text ()
 			result = "Status: Wallet active";
 			break;
 		case rai_qt::status_types::nominal:
-			result = "Status: Running, Block: ";
-            if (unchecked != 0)
-            {
-                count_string += " (" + std::to_string (unchecked) + ")";
-            }
-            result += count_string.c_str ();
+			result = "Status: Running";
 			break;
 		default:
 			assert (false);
 			break;
 	}
+    
+    result += ", Block: ";
+    if (unchecked != 0)
+    {
+        count_string += " (" + std::to_string (unchecked) + ")";
+    }
+    result += count_string.c_str ();
+    
 	return result;
 }
 

--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -628,6 +628,11 @@ std::string rai_qt::status::text ()
 {
 	assert (!active.empty ());
 	std::string result;
+    rai::transaction transaction (wallet.wallet_m->node.store.environment, nullptr, false);
+    auto size (wallet.wallet_m->node.store.block_count (transaction));
+    auto unchecked (wallet.wallet_m->node.store.unchecked_count (transaction));
+    auto count_string (std::to_string (size.sum ()));
+
 	switch (*active.begin ())
 	{
 		case rai_qt::status_types::disconnected:
@@ -637,7 +642,12 @@ std::string rai_qt::status::text ()
 			result = "Status: Generating proof of work";
 			break;
 		case rai_qt::status_types::synchronizing:
-			result = "Status: Synchronizing";
+			result = "Status: Synchronizing, Block: ";
+            if (unchecked != 0)
+            {
+                count_string += " (" + std::to_string (unchecked) + ")";
+            }
+            result += count_string.c_str ();
 			break;
 		case rai_qt::status_types::locked:
 			result = "Status: Wallet locked";
@@ -649,7 +659,12 @@ std::string rai_qt::status::text ()
 			result = "Status: Wallet active";
 			break;
 		case rai_qt::status_types::nominal:
-			result = "Status: Running";
+			result = "Status: Running, Block: ";
+            if (unchecked != 0)
+            {
+                count_string += " (" + std::to_string (unchecked) + ")";
+            }
+            result += count_string.c_str ();
 			break;
 		default:
 			assert (false);


### PR DESCRIPTION
Adds the block count to the status bar (with a tool tip to explain what it means), might make it easier for new users and people trying to support them getting their wallet running. Following up #60 