### PR TITLE
RPC receive

### DIFF
--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1431,13 +1431,13 @@ void rai::rpc_handler::receive ()
 									auto response_a (response);
 									existing->second->receive_async (static_cast <rai::send_block &>(*block), account, rai::genesis_amount, [response_a] (std::unique_ptr <rai::block> block_a)
 									{
-										rai::uint256_union hash (0);
+										rai::uint256_union hash_a (0);
 										if (block_a != nullptr)
 										{
-											hash = block_a->hash ();
+											hash_a = block_a->hash ();
 										}
 										boost::property_tree::ptree response_l;
-										response_l.put ("block", hash.to_string ());
+										response_l.put ("block", hash_a.to_string ());
 										response_a (response_l);
 									});
 								}

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1397,6 +1397,91 @@ void rai::rpc_handler::rai_to_raw ()
 	}
 }
 
+void rai::rpc_handler::receive ()
+{
+	if (rpc.config.enable_control)
+	{
+		std::string wallet_text (request.get <std::string> ("wallet"));
+		rai::uint256_union wallet;
+		auto error (wallet.decode_hex (wallet_text));
+		if (!error)
+		{
+			auto existing (node.wallets.items.find (wallet));
+			if (existing != node.wallets.items.end ())
+			{
+				std::string account_text (request.get <std::string> ("account"));
+				rai::account account;
+				auto error (account.decode_account (account_text));
+				if (!error)
+				{
+					rai::transaction transaction (node.store.environment, nullptr, false);
+					auto account_check (existing->second->store.find (transaction, account));
+					if (account_check != existing->second->store.end ())
+						{
+						std::string hash_text (request.get <std::string> ("block"));
+						rai::uint256_union hash;
+						auto error (hash.decode_hex (hash_text));
+						if (!error)
+						{
+							auto block (node.store.block_get (transaction, hash));
+							if (block != nullptr)
+							{
+								if (node.store.pending_exists (transaction, rai::pending_key (account, hash)))
+								{
+									auto response_a (response);
+									existing->second->receive_async (static_cast <rai::send_block &>(*block), account, rai::genesis_amount, [response_a] (std::unique_ptr <rai::block> block_a)
+									{
+										rai::uint256_union hash (0);
+										if (block_a != nullptr)
+										{
+											hash = block_a->hash ();
+										}
+										boost::property_tree::ptree response_l;
+										response_l.put ("block", hash.to_string ());
+										response_a (response_l);
+									});
+								}
+								else
+								{
+									error_response (response, "Block is not available to receive");
+								}
+							}
+							else
+							{
+								error_response (response, "Block not found");
+							}
+						}
+						else
+						{
+							error_response (response, "Bad block number");
+						}
+					}
+					else
+					{
+						error_response (response, "Account not found in wallet");
+					}
+				}
+				else
+				{
+					error_response (response, "Bad account number");
+				}
+			}
+			else
+			{
+				error_response (response, "Wallet not found");
+			}
+		}
+		else
+		{
+			error_response (response, "Bad wallet number");
+		}
+	}
+	else
+	{
+		error_response (response, "RPC control is disabled");
+	}
+}
+
 void rai::rpc_handler::representatives ()
 {
 	boost::property_tree::ptree response_l;
@@ -2259,6 +2344,10 @@ void rai::rpc_handler::process_request ()
 		else if (action == "rai_to_raw")
 		{
 			rai_to_raw ();
+		}
+		else if (action == "receive")
+		{
+			receive ();
 		}
 		else if (action == "representatives")
 		{

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -129,6 +129,7 @@ public:
 	void process ();
 	void rai_to_raw ();
 	void rai_from_raw ();
+	void receive ();
 	void representatives ();
 	void republish ();
 	void search_pending ();


### PR DESCRIPTION
Will be useful if someone send less than threshold, but cumulative > threshold. Such as 99 + 99 > 100 and cannot be received by current exchanges