### PR TITLE
RPC extended

### DIFF
--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -2171,7 +2171,7 @@ TEST (rpc, pending_threshold)
 	rai::rpc rpc (system.service, *system.nodes [0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
-	request.put ("action", "pending_threshold");
+	request.put ("action", "pending");
 	request.put ("account", key1.pub.to_account ());
 	request.put ("threshold", "100");
 	test_response response0 (request, rpc, system.service);
@@ -2204,7 +2204,7 @@ TEST (rpc, accounts_pending_threshold)
 	rai::rpc rpc (system.service, *system.nodes [0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
-	request.put ("action", "accounts_pending_threshold");
+	request.put ("action", "accounts_pending");
 	boost::property_tree::ptree entry;
 	boost::property_tree::ptree peers_l;
 	entry.put ("", key1.pub.to_account ());
@@ -2295,7 +2295,7 @@ TEST (rpc, wallet_pending_threshold)
 	rai::rpc rpc (system0.service, *system0.nodes [0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
-	request.put ("action", "wallet_pending_threshold");
+	request.put ("action", "wallet_pending");
 	request.put ("wallet", system0.nodes [0]->wallets.items.begin ()->first.to_string ());
 	request.put ("threshold", "100");
 	test_response response0 (request, rpc, system0.service);

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1916,6 +1916,21 @@ void rai::rpc_handler::search_pending ()
 	}
 }
 
+void rai::rpc_handler::search_pending_all ()
+{
+	if (rpc.config.enable_control)
+	{
+		node.wallets.search_pending_all ();
+		boost::property_tree::ptree response_l;
+		response_l.put ("success", "");
+		response (response_l);
+	}
+	else
+	{
+		error_response (response, "RPC control is disabled");
+	}
+}
+
 void rai::rpc_handler::send ()
 {
 	if (rpc.config.enable_control)
@@ -2944,6 +2959,10 @@ void rai::rpc_handler::process_request ()
 		else if (action == "search_pending")
 		{
 			search_pending ();
+		}
+		else if (action == "search_pending_all")
+		{
+			search_pending_all ();
 		}
 		else if (action == "send")
 		{

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1883,8 +1883,6 @@ void rai::rpc_handler::republish ()
 			for (auto i (0); !hash.is_zero () && i < count; ++i)
 			{
 				block = node.store.block_get (transaction, hash);
-				node.network.republish_block (std::move (block));
-				hash = node.store.block_successor (transaction, hash);
 				if (sources != 0) // Republish source chain
 				{
 					std::unique_ptr <rai::block> block_a;
@@ -1906,10 +1904,11 @@ void rai::rpc_handler::republish ()
 						blocks.push_back (std::make_pair ("", entry_l));
 					}
 				}
-				// Republish block
+				node.network.republish_block (std::move (block)); // Republish block
 				boost::property_tree::ptree entry;
 				entry.put ("", hash.to_string ());
 				blocks.push_back (std::make_pair ("", entry));
+				hash = node.store.block_successor (transaction, hash);
 			}
 			response_l.put ("success", ""); // obsolete
 			response_l.add_child ("blocks", blocks);

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1780,6 +1780,37 @@ void rai::rpc_handler::receive ()
 	}
 }
 
+void rai::rpc_handler::receive_minimum ()
+{
+	boost::property_tree::ptree response_l;
+	response_l.put ("amount", node.config.receive_minimum.to_string_dec ());
+	response (response_l);
+}
+
+void rai::rpc_handler::receive_minimum_set ()
+{
+	if (rpc.config.enable_control)
+	{
+		std::string amount_text (request.get <std::string> ("amount"));
+		rai::uint128_union amount;
+		if (!amount.decode_dec (amount_text))
+		{
+			node.config.receive_minimum = amount;
+			boost::property_tree::ptree response_l;
+			response_l.put ("success", "");
+			response (response_l);
+		}
+		else
+		{
+			error_response (response, "Bad amount number");
+		}
+	}
+	else
+	{
+		error_response (response, "RPC control is disabled");
+	}
+}
+
 void rai::rpc_handler::representatives ()
 {
 	boost::property_tree::ptree response_l;
@@ -2860,6 +2891,14 @@ void rai::rpc_handler::process_request ()
 		else if (action == "receive")
 		{
 			receive ();
+		}
+		else if (action == "receive_minimum")
+		{
+			receive_minimum ();
+		}
+		else if (action == "receive_minimum_set")
+		{
+			receive_minimum_set ();
 		}
 		else if (action == "representatives")
 		{

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -588,7 +588,7 @@ void rai::rpc_handler::accounts_frontiers ()
 
 void rai::rpc_handler::accounts_pending ()
 {
-	uint64_t count (18446744073709551615U);
+	uint64_t count (std::numeric_limits <uint64_t>::max ());
 	rai::uint128_union threshold (0);
 	try
 	{
@@ -1347,7 +1347,7 @@ void rai::rpc_handler::pending ()
 	rai::account account;
 	if (!account.decode_account(account_text))
 	{
-		uint64_t count (18446744073709551615U);
+		uint64_t count (std::numeric_limits <uint64_t>::max ());
 		rai::uint128_union threshold (0);
 		try
 		{
@@ -2430,7 +2430,7 @@ void rai::rpc_handler::wallet_pending ()
 		auto existing (node.wallets.items.find (wallet));
 		if (existing != node.wallets.items.end ())
 		{
-			uint64_t count (18446744073709551615U);
+			uint64_t count (std::numeric_limits <uint64_t>::max ());
 			rai::uint128_union threshold (0);
 			try
 			{

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -630,9 +630,9 @@ void rai::rpc_handler::accounts_pending ()
 			for (auto i (node.store.pending_begin (transaction, rai::pending_key (account, 0))), n (node.store.pending_begin (transaction, rai::pending_key (end, 0))); i != n && peers_l.size () < count; ++i)
 			{
 				rai::pending_key key (i->first);
-				boost::property_tree::ptree entry;
 				if (threshold.is_zero ())
 				{
+					boost::property_tree::ptree entry;
 					entry.put ("", key.hash.to_string ());
 					peers_l.push_back (std::make_pair ("", entry));
 				}
@@ -641,8 +641,7 @@ void rai::rpc_handler::accounts_pending ()
 					rai::pending_info info (i->second);
 					if (info.amount.number () >= threshold.number ())
 					{
-						entry.put (key.hash.to_string (), info.amount.number ().convert_to <std::string> ());
-						peers_l.push_back (std::make_pair ("", entry));
+						peers_l.put (key.hash.to_string (), info.amount.number ().convert_to <std::string> ());
 					}
 				}
 			}
@@ -1384,9 +1383,9 @@ void rai::rpc_handler::pending ()
 			for (auto i (node.store.pending_begin (transaction, rai::pending_key (account, 0))), n (node.store.pending_begin (transaction, rai::pending_key (end, 0))); i != n && peers_l.size ()< count; ++i)
 			{
 				rai::pending_key key (i->first);
-				boost::property_tree::ptree entry;
 				if (threshold.is_zero ())
 				{
+					boost::property_tree::ptree entry;
 					entry.put ("", key.hash.to_string ());
 					peers_l.push_back (std::make_pair ("", entry));
 				}
@@ -1395,8 +1394,7 @@ void rai::rpc_handler::pending ()
 					rai::pending_info info (i->second);
 					if (info.amount.number () >= threshold.number ())
 					{
-						entry.put (key.hash.to_string (), info.amount.number ().convert_to <std::string> ());
-						peers_l.push_back (std::make_pair ("", entry));
+						peers_l.put (key.hash.to_string (), info.amount.number ().convert_to <std::string> ());
 					}
 				}
 			}
@@ -2471,9 +2469,9 @@ void rai::rpc_handler::wallet_pending ()
 				for (auto ii (node.store.pending_begin (transaction, rai::pending_key (account, 0))), nn (node.store.pending_begin (transaction, rai::pending_key (end, 0))); ii != nn && peers_l.size ()< count; ++ii)
 				{
 					rai::pending_key key (ii->first);
-					boost::property_tree::ptree entry;
 					if (threshold.is_zero ())
 					{
+						boost::property_tree::ptree entry;
 						entry.put ("", key.hash.to_string ());
 						peers_l.push_back (std::make_pair ("", entry));
 					}
@@ -2482,8 +2480,7 @@ void rai::rpc_handler::wallet_pending ()
 						rai::pending_info info (ii->second);
 						if (info.amount.number () >= threshold.number ())
 						{
-							entry.put (key.hash.to_string (), info.amount.number ().convert_to <std::string> ());
-							peers_l.push_back (std::make_pair ("", entry));
+							peers_l.put (key.hash.to_string (), info.amount.number ().convert_to <std::string> ());
 						}
 					}
 				}
@@ -2492,7 +2489,7 @@ void rai::rpc_handler::wallet_pending ()
 					pending.add_child (account.to_account (), peers_l);
 				}
 			}
-			response_l.add_child ("pending", pending);
+			response_l.add_child ("blocks", pending);
 			response (response_l);
 		}
 		else

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -104,6 +104,7 @@ public:
 	void accounts_balances ();
 	void accounts_frontiers ();
 	void accounts_pending ();
+	void accounts_pending_threshold ();
 	void available_supply ();
 	void block ();
 	void blocks ();
@@ -132,6 +133,7 @@ public:
 	void payment_wait ();
 	void peers ();
 	void pending ();
+	void pending_threshold ();
 	void process ();
 	void rai_to_raw ();
 	void rai_from_raw ();

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -164,6 +164,7 @@ public:
 	void wallet_pending_threshold ();
 	void wallet_representative ();
 	void wallet_representative_set ();
+	void wallet_work_get ();
 	void work_generate ();
 	void work_cancel ();
 	void work_get ();

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -133,6 +133,7 @@ public:
 	void payment_wait ();
 	void peers ();
 	void pending ();
+	void pending_exists ();
 	void pending_threshold ();
 	void process ();
 	void rai_to_raw ();

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -104,7 +104,6 @@ public:
 	void accounts_balances ();
 	void accounts_frontiers ();
 	void accounts_pending ();
-	void accounts_pending_threshold ();
 	void available_supply ();
 	void block ();
 	void blocks ();
@@ -134,7 +133,6 @@ public:
 	void peers ();
 	void pending ();
 	void pending_exists ();
-	void pending_threshold ();
 	void process ();
 	void rai_to_raw ();
 	void rai_from_raw ();
@@ -161,7 +159,6 @@ public:
 	void wallet_frontiers ();
 	void wallet_key_valid ();
 	void wallet_pending ();
-	void wallet_pending_threshold ();
 	void wallet_representative ();
 	void wallet_representative_set ();
 	void wallet_work_get ();

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -156,6 +156,8 @@ public:
 	void wallet_export ();
 	void wallet_frontiers ();
 	void wallet_key_valid ();
+	void wallet_pending ();
+	void wallet_pending_threshold ();
 	void wallet_representative ();
 	void wallet_representative_set ();
 	void work_generate ();

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -166,6 +166,8 @@ public:
 	void wallet_representative_set ();
 	void work_generate ();
 	void work_cancel ();
+	void work_get ();
+	void work_set ();
 	void work_validate ();
 	std::string body;
 	rai::node & node;

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -161,6 +161,7 @@ public:
 	void wallet_pending ();
 	void wallet_representative ();
 	void wallet_representative_set ();
+	void wallet_republish ();
 	void wallet_work_get ();
 	void work_generate ();
 	void work_cancel ();

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -144,6 +144,7 @@ public:
 	void representatives ();
 	void republish ();
 	void search_pending ();
+	void search_pending_all ();
 	void send ();
 	void stop ();
 	void successors ();

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -138,6 +138,8 @@ public:
 	void rai_to_raw ();
 	void rai_from_raw ();
 	void receive ();
+	void receive_minimum ();
+	void receive_minimum_set ();
 	void representatives ();
 	void republish ();
 	void search_pending ();


### PR DESCRIPTION
+ pending, accounts_pending to accept "threshold" parameter
+ **wallet_pending**
+ **pending_exists** (to check if transaction is completed with receive)
+ **search_pending_all** (to search pending for all wallets)
+ **receive_minimum, receive_minimum_set** (to change receive_minimum without node restart)
+ republish to accept "sources" parameter (depth of rebroadcast for receive/open source chains)
+ **wallet_republish** (to rebroadcast last blocks from all wallet accounts)
+ **work_get, work_set, wallet_work_get** (https://github.com/clemahieu/raiblocks/issues/95)

