### PR TITLE
Add Access-Control-Allow-Headers to RPC responses

### DIFF
--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -1385,9 +1385,11 @@ TEST (rpc, version)
     ASSERT_EQ (200, response1.status);
 	ASSERT_EQ ("10", response1.json.get <std::string> ("store_version"));
 	ASSERT_EQ (boost::str (boost::format ("RaiBlocks %1%.%2%") % RAIBLOCKS_VERSION_MAJOR % RAIBLOCKS_VERSION_MINOR), response1.json.get <std::string> ("node_vendor"));
-	auto headers (response1.resp.find ("Access-Control-Allow-Origin"));
-	ASSERT_NE (response1.resp.end (), headers);
-	ASSERT_EQ ("*", headers->value ());
+	auto headers (response1.resp.base());
+	auto allowed_origin (headers.at ("Access-Control-Allow-Origin"));
+	auto allowed_headers (headers.at ("Access-Control-Allow-Headers"));
+	ASSERT_EQ ("*", allowed_origin);
+	ASSERT_EQ ("Accept, Accept-Language, Content-Language, Content-Type", allowed_headers);
 }
 
 TEST (rpc, work_generate)

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -4107,8 +4107,9 @@ void rai::rpc_connection::parse_connection ()
 					boost::property_tree::write_json (ostream, tree_a);
 					ostream.flush ();
 					auto body (ostream.str ());
-					this_l->res.set ("content-type", "application/json");
-					this_l->res.set ("Access-Control-Allow-Origin",  "*");
+					this_l->res.set ("Content-Type", "application/json");
+					this_l->res.set ("Access-Control-Allow-Origin", "*");
+					this_l->res.set ("Access-Control-Allow-Headers", "Accept, Accept-Language, Content-Language, Content-Type");
 					this_l->res.result(boost::beast::http::status::ok);
 					this_l->res.body = body;
 					this_l->res.version = version;


### PR DESCRIPTION
This allows cross-origin requests in a sandboxed environment sending [CORS-safelisted request headers](https://developer.mozilla.org/en-US/docs/Glossary/Simple_header) such as  `Content-Type`.

More headers can be allowed in the future or we can echo back the request's `Access-Control-Request-Headers` if it exists, but this is a start.

Allowing any header using `*` is not well supported.

See: https://stackoverflow.com/a/13147554