### PR TITLE
Upgrade our Boost.Beast dependency to version 144

### DIFF
--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -26,19 +26,19 @@ public:
 				boost::property_tree::write_json (ostream, request);
 				req.method (boost::beast::http::verb::post);
 				req.target ("/");
-				req.version = 11;
+				req.version (11);
 				ostream.flush ();
-				req.body = ostream.str ();
+				req.body() = ostream.str ();
 				req.prepare_payload ();
-				boost::beast::http::async_write (sock, req, [this] (boost::system::error_code const & ec)
+				boost::beast::http::async_write (sock, req, [this] (boost::system::error_code const & ec, size_t bytes_transferred)
 				{
 					if (!ec)
 					{
-						boost::beast::http::async_read(sock, sb, resp, [this] (boost::system::error_code const & ec)
+						boost::beast::http::async_read(sock, sb, resp, [this] (boost::system::error_code const & ec, size_t bytes_transferred)
 						{
 							if (!ec)
 							{
-								std::stringstream body (resp.body);
+								std::stringstream body (resp.body());
 								try
 								{
 									boost::property_tree::read_json (body, json);

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1374,19 +1374,19 @@ block_processor_thread ([this] () { this->block_processor.process_blocks (); })
 										auto req (std::make_shared <boost::beast::http::request<boost::beast::http::string_body>> ());
 										req->method (boost::beast::http::verb::post);
 										req->target (*target);
-										req->version = 11;
+										req->version (11);
 										req->insert(boost::beast::http::field::host, address);
-										req->body = *body;
+										req->body() = *body;
 										//req->prepare (*req);
 										//boost::beast::http::prepare(req);
 										req->prepare_payload();
-										boost::beast::http::async_write (*sock, *req, [node_l, sock, address, port, req] (boost::system::error_code const & ec)
+										boost::beast::http::async_write (*sock, *req, [node_l, sock, address, port, req] (boost::system::error_code const & ec, size_t bytes_transferred)
 										{
 											if (!ec)
 											{
 												auto sb (std::make_shared <boost::beast::flat_buffer> ());
 												auto resp (std::make_shared <boost::beast::http::response <boost::beast::http::string_body>> ());
-												boost::beast::http::async_read (*sock, *sb, *resp, [node_l, sb, resp, sock, address, port] (boost::system::error_code const & ec)
+												boost::beast::http::async_read (*sock, *sb, *resp, [node_l, sb, resp, sock, address, port] (boost::system::error_code const & ec, size_t bytes_transferred)
 												{
 													if (!ec)
 													{
@@ -2002,20 +2002,20 @@ void start ()
 						auto request (std::make_shared <boost::beast::http::request <boost::beast::http::string_body>> ());
 						request->method (boost::beast::http::verb::post);
 						request->target ("/");
-						request->version = 11;
-						request->body = request_string;
+						request->version (11);
+						request->body() = request_string;
 						request->prepare_payload ();
-						boost::beast::http::async_write (connection->socket, *request, [this_l, connection, request] (boost::system::error_code const & ec)
+						boost::beast::http::async_write (connection->socket, *request, [this_l, connection, request] (boost::system::error_code const & ec, size_t bytes_transferred)
 						{
 							if (!ec)
 							{
-								boost::beast::http::async_read (connection->socket, connection->buffer, connection->response, [this_l, connection] (boost::system::error_code const & ec)
+								boost::beast::http::async_read (connection->socket, connection->buffer, connection->response, [this_l, connection] (boost::system::error_code const & ec, size_t bytes_transferred)
 								{
 									if (!ec)
 									{
 										if (connection->response.result() == boost::beast::http::status::ok)
 										{
-											this_l->success (connection->response.body, connection->address);
+											this_l->success (connection->response.body(), connection->address);
 										}
 										else
 										{
@@ -2073,11 +2073,11 @@ void stop ()
 			boost::beast::http::request <boost::beast::http::string_body> request;
 			request.method (boost::beast::http::verb::post);
 			request.target ("/");
-			request.version = 11;
-			request.body = request_string;
+			request.version (11);
+			request.body() = request_string;
 			request.prepare_payload();
 			auto socket (std::make_shared <boost::asio::ip::tcp::socket> (this_l->node->service));
-			boost::beast::http::async_write (*socket, request, [socket] (boost::system::error_code const & ec)
+			boost::beast::http::async_write (*socket, request, [socket] (boost::system::error_code const & ec, size_t bytes_transferred)
 			{
 			});
 		});

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -4093,14 +4093,14 @@ socket (node_a.service)
 void rai::rpc_connection::parse_connection ()
 {
 	auto this_l (shared_from_this ());
-	boost::beast::http::async_read (socket, buffer, request, [this_l] (boost::system::error_code const & ec)
+	boost::beast::http::async_read (socket, buffer, request, [this_l] (boost::system::error_code const & ec, size_t bytes_transferred)
 	{
 		if (!ec)
 		{
 			this_l->node->background ([this_l] ()
 			{
 				auto start (std::chrono::system_clock::now ());
-				auto version (this_l->request.version);
+				auto version (this_l->request.version());
 				auto response_handler ([this_l, version, start] (boost::property_tree::ptree const & tree_a)
 				{
 					std::stringstream ostream;
@@ -4110,11 +4110,11 @@ void rai::rpc_connection::parse_connection ()
 					this_l->res.set ("content-type", "application/json");
 					this_l->res.set ("Access-Control-Allow-Origin",  "*");
 					this_l->res.result(boost::beast::http::status::ok);
-					this_l->res.body = body;
-					this_l->res.version = version;
+					this_l->res.body() = body;
+					this_l->res.version (version);
 					this_l->res.prepare_payload();
 					//boost::beast::http::prepare (this_l->res);
-					boost::beast::http::async_write (this_l->socket, this_l->res, [this_l] (boost::system::error_code const & ec)
+					boost::beast::http::async_write (this_l->socket, this_l->res, [this_l] (boost::system::error_code const & ec, size_t bytes_transferred)
 					{
 					});
 					if (this_l->node->config.logging.log_rpc ())
@@ -4124,7 +4124,7 @@ void rai::rpc_connection::parse_connection ()
 				});
 				if (this_l->request.method () == boost::beast::http::verb::post)
 				{
-					auto handler (std::make_shared <rai::rpc_handler> (*this_l->node, this_l->rpc, this_l->request.body, response_handler));
+					auto handler (std::make_shared <rai::rpc_handler> (*this_l->node, this_l->rpc, this_l->request.body(), response_handler));
 					handler->process_request ();
 				}
 				else


### PR DESCRIPTION
**This requires Boost >= 1.66.**

Along with bug fixes and performance improvements, it seems to have fixed the zombie bind issues (at least on macOS 10.13).