### PR TITLE
switch CI to use testnet

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -57,6 +57,7 @@ run_build() {
     mkdir ${build_dir}
     cd ${build_dir}
     cmake -GNinja \
+       -DACTIVE_NETWORK=rai_test_network \
        -DRAIBLOCKS_TEST=ON \
        -DRAIBLOCKS_GUI=ON \
        -DCMAKE_BUILD_TYPE=Debug \


### PR DESCRIPTION
Many tests in core_test operate under the assumption that genesis and other account data is populated with testnet values. This means core_test requires being built targeting the testnet. Whether or not this may cause coverage issues I don't know.