### PR TITLE
Supressing openclwork.cpp deprecation warnings

### DIFF
--- a/rai/node/openclwork.hpp
+++ b/rai/node/openclwork.hpp
@@ -12,7 +12,8 @@
 #ifdef __APPLE__
 #include <OpenCL/opencl.h>
 #else
-#include <CL/cl.h>	
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+#include <CL/cl.h>
 #endif
 
 namespace rai


### PR DESCRIPTION
openclwork.cpp:570:13: warning: ‘_cl_command_queue*
clCreateCommandQueue(cl_context, cl_device_id,
cl_command_queue_properties, cl_int*)’ is deprecated
[-Wdeprecated-declarations]
queue = clCreateCommandQueue (context, selected_devices [0], 0,
&queue_error);