### PR TITLE
combine lock & unlock button into a single button + password field

### DIFF
--- a/rai/qt/qt.hpp
+++ b/rai/qt/qt.hpp
@@ -32,10 +32,7 @@ namespace rai_qt {
         QWidget * window;
         QVBoxLayout * layout;
         QLineEdit * password;
-		QWidget * lock_window;
-		QHBoxLayout * lock_layout;
-        QPushButton * unlock;
-        QPushButton * lock;
+		QPushButton * lock_toggle;
 		QFrame * sep1;
         QLineEdit * new_password;
         QLineEdit * retype_password;


### PR DESCRIPTION
This pull request combines the "Lock" and "Unlock" button into a single button which is toggled depending on the lock state.

Additionally, it will disable the password field when the wallet is unlocked. 

Unlocked wallet:
![image](https://user-images.githubusercontent.com/885856/34414499-f1b2acc2-ebe9-11e7-8dcb-12249a8e3d72.png)

Locked wallet:
![image](https://user-images.githubusercontent.com/885856/34414514-017eb09c-ebea-11e7-8535-617619afd140.png)

This fixes #237, #279, #288 