### PR TITLE
Fix #331

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2631,9 +2631,9 @@ void rai::peer_container::contacted (rai::endpoint const & endpoint_a, unsigned 
 	insert (endpoint_l, version_a);
 }
 
-std::ostream & operator << (std::ostream & stream_a, std::chrono::system_clock::time_point const & time_a)
+std::ostream & operator << (std::ostream & stream_a, rai::time_point_wrapper const & time_a)
 {
-    time_t last_contact (std::chrono::system_clock::to_time_t (time_a));
+    time_t last_contact (std::chrono::system_clock::to_time_t (time_a.time));
     std::string string (ctime (&last_contact));
     string.pop_back ();
     stream_a << string;

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -23,7 +23,18 @@
 
 #include <miniupnpc.h>
 
-std::ostream & operator << (std::ostream &, std::chrono::system_clock::time_point const &);
+namespace rai
+{
+// time_point_wrapper - Used to provide an overload for `std::iostream`
+// for passing `std::chrono::system_clock::time_point`. Overloading
+// it directly would be undefined behavior as per [namespace.std]/1.
+struct time_point_wrapper
+{
+	std::chrono::system_clock::time_point time;
+};
+}
+
+std::ostream & operator << (std::ostream &, rai::time_point_wrapper const &);
 
 namespace boost
 {
@@ -349,7 +360,7 @@ public:
     bool work_generation_time () const;
     bool log_to_cerr () const;
 	void init (boost::filesystem::path const &);
-	
+
 	bool ledger_logging_value;
 	bool ledger_duplicate_logging_value;
 	bool vote_logging_value;


### PR DESCRIPTION
This code specifically:

    std::ostream & operator << (std::ostream & stream_a,
                                std::chrono::system_clock::time_point const & time_a)

contains undefined behavior as per namespace.std]/1:

> The behavior of a C++ program is undefined if it adds declarations or
> definitions to namespace std or to a namespace within namespace std unless
> otherwise specified.  A program may add a template specialization for any
> standard library template to namespace std only if the declaration depends
> on a user-defined type and the specialization meets the standard library
> requirements for the original template and is not explicitly prohibited.

[namespace.std]/3 also applies:

> A program may explicitly instantiate a template defined in the standard
> library only if the declaration depends on the name of a user-defined
> type and the instantiation meets the standard library requirements for
> the original template.

This fix wraps `std::chrono::system_clock::time_point` inside
a user-defined type `rai::time_point_wrapper`.