### PR TITLE
Add docker data volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN chmod +x /usr/local/bin/rai_node_init.sh
 
 WORKDIR /root
 
+VOLUME /root/RaiBlocks
+
 EXPOSE 7075 7076
 
 ENTRYPOINT ["/bin/bash", "/usr/local/bin/rai_node_init.sh"]


### PR DESCRIPTION
This automatically creates a container volume for the database and log files. Using a data volume greatly enhances performance since the database would otherwise be stored within the container's layered filesystem(which is an anti pattern).

By default this creates the volume on the host's filesystem on the first container start. Using Docker's volume opens possibilities for many types of storage options. See Docker's volume [documentation](https://docs.docker.com/engine/admin/volumes/) for more details.

No need to manually specify the "docker run -v /foo:/bar" parameter anymore.
cc @zjeraar 