### PR TITLE
Update wallet.enter_password test for lock toggle button

### DIFF
--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -1466,6 +1466,15 @@ wallet (wallet_a)
 			}
 		}
 	});
+
+	// initial state for lock toggle button
+	rai::transaction transaction (this->wallet.wallet_m->store.environment, nullptr, true);
+	if (this->wallet.wallet_m->store.valid_password (transaction)) 
+	{
+		lock_toggle->setText("Lock");
+		password->setDisabled(1);
+	}
+
 	representative->setToolTip ("In the infrequent case where the network needs to make a global decision,\nyour wallet software performs a balance-weighted vote to determine\nthe outcome. Since not everyone can remain online and perform this duty,\nyour wallet names a representative that can vote with, but cannot spend,\nyour balance.");
 	refresh_representative ();
 }

--- a/rai/qt_test/qt.cpp
+++ b/rai/qt_test/qt.cpp
@@ -213,24 +213,22 @@ TEST (wallet, enter_password)
     ASSERT_NE (-1, wallet->settings.layout->indexOf (wallet->settings.password));
     ASSERT_NE (-1, wallet->settings.layout->indexOf (wallet->settings.lock_toggle));
     ASSERT_NE (-1, wallet->settings.layout->indexOf (wallet->settings.back));
-    QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
+    QTest::mouseClick (wallet->settings_button, Qt::LeftButton);
 	test_application->processEvents();
-    ASSERT_EQ ("Status: Wallet password empty", wallet->status->text ());
+    ASSERT_EQ ("Status: Wallet password empty", wallet->status->text ().toStdString ());
 	{
 		rai::transaction transaction (system.nodes [0]->store.environment, nullptr, true);
 		ASSERT_FALSE (system.wallet (0)->store.rekey (transaction, "abc"));
 	}
     QTest::mouseClick (wallet->settings_button, Qt::LeftButton);
-    QTest::keyClicks (wallet->settings.new_password, "a");
     QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents();
-    ASSERT_EQ ("Status: Wallet locked", wallet->status->text ());
+    ASSERT_EQ ("Status: Wallet locked", wallet->status->text ().toStdString ());
     wallet->settings.new_password->setText ("");
     QTest::keyClicks (wallet->settings.password, "abc");
     QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents();
-	auto status (wallet->status->text ());
-    ASSERT_EQ ("Status: Running", status);
+    ASSERT_EQ ("Status: Running", wallet->status->text ().toStdString ());
     ASSERT_EQ ("", wallet->settings.password->text ());
 }
 

--- a/rai/qt_test/qt.cpp
+++ b/rai/qt_test/qt.cpp
@@ -211,10 +211,9 @@ TEST (wallet, enter_password)
     auto wallet (std::make_shared <rai_qt::wallet> (*test_application, processor, *system.nodes [0], system.wallet (0), account));
 	wallet->start ();
     ASSERT_NE (-1, wallet->settings.layout->indexOf (wallet->settings.password));
-    ASSERT_NE (-1, wallet->settings.lock_layout->indexOf (wallet->settings.unlock));
-    ASSERT_NE (-1, wallet->settings.lock_layout->indexOf (wallet->settings.lock));
+    ASSERT_NE (-1, wallet->settings.layout->indexOf (wallet->settings.lock_toggle));
     ASSERT_NE (-1, wallet->settings.layout->indexOf (wallet->settings.back));
-    QTest::mouseClick (wallet->settings.unlock, Qt::LeftButton);
+    QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents();
     ASSERT_EQ ("Status: Wallet password empty", wallet->status->text ());
 	{
@@ -223,12 +222,12 @@ TEST (wallet, enter_password)
 	}
     QTest::mouseClick (wallet->settings_button, Qt::LeftButton);
     QTest::keyClicks (wallet->settings.new_password, "a");
-    QTest::mouseClick (wallet->settings.unlock, Qt::LeftButton);
+    QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents();
     ASSERT_EQ ("Status: Wallet locked", wallet->status->text ());
     wallet->settings.new_password->setText ("");
     QTest::keyClicks (wallet->settings.password, "abc");
-    QTest::mouseClick (wallet->settings.unlock, Qt::LeftButton);
+    QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents();
 	auto status (wallet->status->text ());
     ASSERT_EQ ("Status: Running", status);


### PR DESCRIPTION
Following up on #311, this pull request sets the proper initial state for the toggle button for new wallets. It also updates `qt_test` to take the new flow into account.

I'm quite new to C so please let me know if there's anything that can be improved upon here.