### PR TITLE
Remove unused count field from bulk_pull.

### DIFF
--- a/rai/node/common.hpp
+++ b/rai/node/common.hpp
@@ -200,7 +200,6 @@ public:
     void visit (rai::message_visitor &) const override;
     rai::uint256_union start;
     rai::block_hash end;
-    uint32_t count;
 };
 class bulk_push : public message
 {


### PR DESCRIPTION
I checked older versions, and it seems that this has never been used. Maybe the intention was to reuse bulk_pull for range queries (which @clemahieu has mentioned as a need - and which would require a count -  but new messages types are probably more appropriate)