### PR TITLE
Vacuum feature

### DIFF
--- a/rai/core_test/wallet.cpp
+++ b/rai/core_test/wallet.cpp
@@ -889,17 +889,20 @@ TEST (wallet, password_race)
 	rai::thread_runner runner (system.service, system.nodes[0]->config.io_threads);
 	auto wallet = system.wallet (0);
 	system.nodes[0]->background ([&wallet]() {
-		for (int i = 0; i < 100; i++) {
+		for (int i = 0; i < 100; i++)
+		{
 			rai::transaction transaction (wallet->store.environment, nullptr, true);
-			wallet->store.rekey (transaction, std::to_string(i));
+			wallet->store.rekey (transaction, std::to_string (i));
 		}
 	});
-	for (int i = 0; i < 100; i++) {
+	for (int i = 0; i < 100; i++)
+	{
 		rai::transaction transaction (wallet->store.environment, nullptr, false);
 		// Password should always be valid, the rekey operation should be atomic.
 		bool ok = wallet->store.valid_password (transaction);
 		EXPECT_TRUE (ok);
-		if (!ok) {
+		if (!ok)
+		{
 			break;
 		}
 	}

--- a/rai/lib/blocks.cpp
+++ b/rai/lib/blocks.cpp
@@ -20,7 +20,7 @@ bool rai::from_string_hex (std::string const & value_a, uint64_t & target_a)
 			stream << std::hex << std::noshowbase;
 			try
 			{
-                		uint64_t number_l;
+				uint64_t number_l;
 				stream >> number_l;
 				target_a = number_l;
 				if (!stream.eof ())

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1343,7 +1343,7 @@ warmed_up (0),
 block_processor (*this),
 block_processor_thread ([this]() { this->block_processor.process_blocks (); })
 {
-	wallets.observer = [this] (bool active) {
+	wallets.observer = [this](bool active) {
 		observers.wallet (active);
 	};
 	peers.peer_observer = [this](rai::endpoint const & endpoint_a) {
@@ -1510,7 +1510,7 @@ rai::node::~node ()
 bool rai::node::copy_with_compaction (boost::filesystem::path const & destination_file)
 {
 	return !mdb_env_copy2 (store.environment.environment,
-						   destination_file.string ().c_str (), MDB_CP_COMPACT);
+	destination_file.string ().c_str (), MDB_CP_COMPACT);
 }
 
 void rai::node::send_keepalive (rai::endpoint const & endpoint_a)
@@ -2783,9 +2783,9 @@ void rai::active_transactions::announce_votes ()
 	std::vector<rai::block_hash> inactive;
 	rai::transaction transaction (node.store.environment, nullptr, true);
 	std::lock_guard<std::mutex> lock (mutex);
-	
+
 	{
-        	size_t announcements (0);
+		size_t announcements (0);
 		auto i (roots.begin ());
 		auto n (roots.end ());
 		// Announce our decision for up to `announcements_per_interval' conflicts
@@ -3009,13 +3009,13 @@ bool rai::handle_node_options (boost::program_options::variables_map & vm)
 		try
 		{
 			boost::filesystem::path data_path = vm.count ("data_path") ? boost::filesystem::path (vm["data_path"].as<std::string> ()) : rai::working_path ();
-			
+
 			auto vacuum_path = data_path / "vacuumed.ldb";
 			auto source_path = data_path / "data.ldb";
 			auto backup_path = data_path / "backup.vacuum.ldb";
 
 			std::cout << "Vacuuming database copy in " << data_path << std::endl;
-			std::cout << "This may take a while..."  << std::endl;
+			std::cout << "This may take a while..." << std::endl;
 
 			// Scope the node so the mdb environment gets cleaned up properly before
 			// the original file is replaced with the vacuumed file.
@@ -3035,9 +3035,9 @@ bool rai::handle_node_options (boost::program_options::variables_map & vm)
 				std::cout << "Vacuum completed" << std::endl;
 			}
 		}
-		catch (const boost::filesystem::filesystem_error& ex)
+		catch (const boost::filesystem::filesystem_error & ex)
 		{
-			std::cerr << "Vacuum failed during a file operation: " << ex.what() << std::endl;
+			std::cerr << "Vacuum failed during a file operation: " << ex.what () << std::endl;
 		}
 		catch (...)
 		{
@@ -3530,7 +3530,7 @@ bool rai::handle_node_options (boost::program_options::variables_map & vm)
 
 rai::inactive_node::inactive_node (boost::filesystem::path const & path) :
 path (path),
-service (boost::make_shared <boost::asio::io_service> ()),
+service (boost::make_shared<boost::asio::io_service> ()),
 alarm (*service),
 work (1, nullptr)
 {

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1507,6 +1507,12 @@ rai::node::~node ()
 	stop ();
 }
 
+bool rai::node::copy_with_compaction (boost::filesystem::path const & destination_file)
+{
+	return !mdb_env_copy2 (store.environment.environment,
+						   destination_file.string ().c_str (), MDB_CP_COMPACT);
+}
+
 void rai::node::send_keepalive (rai::endpoint const & endpoint_a)
 {
 	auto endpoint_l (endpoint_a);
@@ -2918,7 +2924,7 @@ void rai::thread_runner::join ()
 
 void rai::add_node_options (boost::program_options::options_description & description_a)
 {
-	description_a.add_options () ("account_create", "Insert next deterministic key in to <wallet>") ("account_get", "Get account number for the <key>") ("account_key", "Get the public key for <account>") ("data_path", boost::program_options::value<std::string> (), "Use the supplied path as the data directory") ("diagnostics", "Run internal diagnostics") ("key_create", "Generates a adhoc random keypair and prints it to stdout") ("key_expand", "Derive public key and account number from <key>") ("wallet_add_adhoc", "Insert <key> in to <wallet>") ("wallet_create", "Creates a new wallet and prints the ID") ("wallet_change_seed", "Changes seed for <wallet> to <key>") ("wallet_decrypt_unsafe", "Decrypts <wallet> using <password>, !!THIS WILL PRINT YOUR PRIVATE KEY TO STDOUT!!") ("wallet_destroy", "Destroys <wallet> and all keys it contains") ("wallet_import", "Imports keys in <file> using <password> in to <wallet>") ("wallet_list", "Dumps wallet IDs and public keys") ("wallet_remove", "Remove <account> from <wallet>") ("wallet_representative_get", "Prints default representative for <wallet>") ("wallet_representative_set", "Set <account> as default representative for <wallet>") ("vote_dump", "Dump most recent votes from representatives") ("account", boost::program_options::value<std::string> (), "Defines <account> for other commands") ("file", boost::program_options::value<std::string> (), "Defines <file> for other commands") ("key", boost::program_options::value<std::string> (), "Defines the <key> for other commands, hex") ("password", boost::program_options::value<std::string> (), "Defines <password> for other commands") ("wallet", boost::program_options::value<std::string> (), "Defines <wallet> for other commands");
+	description_a.add_options () ("account_create", "Insert next deterministic key in to <wallet>") ("account_get", "Get account number for the <key>") ("account_key", "Get the public key for <account>") ("vacuum", "Compact database. If data_path is missing, the database in data directory is compacted.") ("data_path", boost::program_options::value<std::string> (), "Use the supplied path as the data directory") ("diagnostics", "Run internal diagnostics") ("key_create", "Generates a adhoc random keypair and prints it to stdout") ("key_expand", "Derive public key and account number from <key>") ("wallet_add_adhoc", "Insert <key> in to <wallet>") ("wallet_create", "Creates a new wallet and prints the ID") ("wallet_change_seed", "Changes seed for <wallet> to <key>") ("wallet_decrypt_unsafe", "Decrypts <wallet> using <password>, !!THIS WILL PRINT YOUR PRIVATE KEY TO STDOUT!!") ("wallet_destroy", "Destroys <wallet> and all keys it contains") ("wallet_import", "Imports keys in <file> using <password> in to <wallet>") ("wallet_list", "Dumps wallet IDs and public keys") ("wallet_remove", "Remove <account> from <wallet>") ("wallet_representative_get", "Prints default representative for <wallet>") ("wallet_representative_set", "Set <account> as default representative for <wallet>") ("vote_dump", "Dump most recent votes from representatives") ("account", boost::program_options::value<std::string> (), "Defines <account> for other commands") ("file", boost::program_options::value<std::string> (), "Defines <file> for other commands") ("key", boost::program_options::value<std::string> (), "Defines the <key> for other commands, hex") ("password", boost::program_options::value<std::string> (), "Defines <password> for other commands") ("wallet", boost::program_options::value<std::string> (), "Defines <wallet> for other commands");
 }
 
 bool rai::handle_node_options (boost::program_options::variables_map & vm)
@@ -2996,6 +3002,54 @@ bool rai::handle_node_options (boost::program_options::variables_map & vm)
 		{
 			std::cerr << "account_key command requires one <account> option\n";
 			result = true;
+		}
+	}
+	else if (vm.count ("vacuum") > 0)
+	{
+		try
+		{
+			boost::filesystem::path data_path;
+			if (vm.count ("data_path"))
+			{
+				data_path = boost::filesystem::path (vm["data_path"].as <std::string> ());
+			}
+			else
+			{
+				data_path = rai::working_path ();
+			}
+			
+			auto vacuum_path = data_path / "vacuumed.ldb";
+			auto source_path = data_path / "data.ldb";
+			auto backup_path = data_path / "backup.vacuum.ldb";
+
+			std::cout << "Vacuuming database copy in " << data_path << std::endl;
+			std::cout << "This may take a while..."  << std::endl;
+
+			// Scope the node so the mdb environment gets cleaned up properly before
+			// the original file is replaced with the vacuumed file.
+			bool success = false;
+			{
+				inactive_node node (data_path);
+				success = node.node->copy_with_compaction (vacuum_path);
+			}
+
+			if (success)
+			{
+				// Note that these throw on failure
+				std::cout << "Finalizing" << std::endl;
+				boost::filesystem::remove (backup_path);
+				boost::filesystem::rename (source_path, backup_path);
+				boost::filesystem::rename (vacuum_path, source_path);
+				std::cout << "Vacuum completed" << std::endl;
+			}
+		}
+		catch (const boost::filesystem::filesystem_error& ex)
+		{
+			std::cout << "Vacuum failed during a file operation: " << ex.what() << std::endl;
+		}
+		catch (...)
+		{
+			std::cout << "Vacuum failed" << std::endl;
 		}
 	}
 	else if (vm.count ("diagnostics"))
@@ -3482,9 +3536,9 @@ bool rai::handle_node_options (boost::program_options::variables_map & vm)
 	return result;
 }
 
-rai::inactive_node::inactive_node () :
-path (rai::working_path ()),
-service (boost::make_shared<boost::asio::io_service> ()),
+rai::inactive_node::inactive_node (boost::filesystem::path const & path) :
+path (path),
+service (boost::make_shared <boost::asio::io_service> ()),
 alarm (*service),
 work (1, nullptr)
 {

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3008,15 +3008,7 @@ bool rai::handle_node_options (boost::program_options::variables_map & vm)
 	{
 		try
 		{
-			boost::filesystem::path data_path;
-			if (vm.count ("data_path"))
-			{
-				data_path = boost::filesystem::path (vm["data_path"].as <std::string> ());
-			}
-			else
-			{
-				data_path = rai::working_path ();
-			}
+			boost::filesystem::path data_path = vm.count ("data_path") ? boost::filesystem::path (vm["data_path"].as<std::string> ()) : rai::working_path ();
 			
 			auto vacuum_path = data_path / "vacuumed.ldb";
 			auto source_path = data_path / "data.ldb";
@@ -3045,11 +3037,11 @@ bool rai::handle_node_options (boost::program_options::variables_map & vm)
 		}
 		catch (const boost::filesystem::filesystem_error& ex)
 		{
-			std::cout << "Vacuum failed during a file operation: " << ex.what() << std::endl;
+			std::cerr << "Vacuum failed during a file operation: " << ex.what() << std::endl;
 		}
 		catch (...)
 		{
-			std::cout << "Vacuum failed" << std::endl;
+			std::cerr << "Vacuum failed" << std::endl;
 		}
 	}
 	else if (vm.count ("diagnostics"))

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -480,6 +480,7 @@ public:
 		alarm.service.post (action_a);
 	}
 	void send_keepalive (rai::endpoint const &);
+	bool copy_with_compaction (boost::filesystem::path const &);
 	void keepalive (std::string const &, uint16_t);
 	void start ();
 	void stop ();
@@ -548,7 +549,7 @@ bool handle_node_options (boost::program_options::variables_map &);
 class inactive_node
 {
 public:
-	inactive_node ();
+	inactive_node (boost::filesystem::path const & path = rai::working_path ());
 	~inactive_node ();
 	boost::filesystem::path path;
 	boost::shared_ptr<boost::asio::io_service> service;

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1202,7 +1202,7 @@ rai::wallets::wallets (bool & error_a, rai::node & node_a) :
 observer ([](bool) {}),
 node (node_a),
 stopped (false),
-thread ([this] () { do_wallet_actions (); })
+thread ([this]() { do_wallet_actions (); })
 {
 	if (!error_a)
 	{
@@ -1303,7 +1303,7 @@ void rai::wallets::destroy (rai::uint256_union const & id_a)
 
 void rai::wallets::do_wallet_actions ()
 {
-	std::unique_lock <std::mutex> lock (mutex);
+	std::unique_lock<std::mutex> lock (mutex);
 	while (!stopped)
 	{
 		if (!actions.empty ())
@@ -1326,7 +1326,7 @@ void rai::wallets::do_wallet_actions ()
 
 void rai::wallets::queue_wallet_action (rai::uint128_t const & amount_a, std::function<void()> const & action_a)
 {
-	std::lock_guard <std::mutex> lock (mutex);
+	std::lock_guard<std::mutex> lock (mutex);
 	actions.insert (std::make_pair (amount_a, std::move (action_a)));
 	condition.notify_all ();
 }
@@ -1374,7 +1374,7 @@ bool rai::wallets::exists (MDB_txn * transaction_a, rai::public_key const & acco
 
 void rai::wallets::stop ()
 {
-	std::lock_guard <std::mutex> lock (mutex);
+	std::lock_guard<std::mutex> lock (mutex);
 	stopped = true;
 	condition.notify_all ();
 }


### PR DESCRIPTION
This PR introduces a --vacuum feature on rai_node / rai_wallet.

Test case, 13GB wallet on a fast SSD:

 * Vacuuming took about 3 minutes
 * Size after vacuum: 5GB

Since lmdb doesn't offer inline vacuuming, the vacuuming dumps live mdb pages to a copy of the db, which is finally replaced by the compacted db.

A general question about the code base: There doesn't seem to be a good place for shared constants (such as strings) in the various subprojects. Should we introduce some sort of `constants.hpp`? Sprinkling copies of string constants like "data.ldb" around is brittle and hard to maintain.
  