### PR TITLE
add resource links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-[![Build Status](https://travis-ci.org/clemahieu/raiblocks.svg?branch=master)](https://travis-ci.org/clemahieu/raiblocks) 
-___
-
+RaiBlocks  
+====
+[![Build Status](https://travis-ci.org/clemahieu/raiblocks.svg?branch=master)](https://travis-ci.org/clemahieu/raiblocks)
 ![Logo of RaiBlocks](https://github.com/clemahieu/raiblocks/blob/master/logo.png)
 
 # What is RaiBlocks?
 RaiBlocks is designed to be a feeless, instant, high throughput cryptocurrency.
 
-We've applied the philosophy of "Do one thing and do it well" giving you performance and scalability unmatched by any other platform.
-
-___
+We've applied the philosophy of "do one thing and do it well", giving you performance and scalability unmatched by any other platform.
 
 ### Key Features:
 * RaiBlocks utilizes a novel block-lattice architecture, unlike conventional blockchains used in many other cryptocurrencies.
@@ -16,14 +14,19 @@ ___
 * Offers feeless, instantaneous transactions, as well as unlimited scalability, making RaiBlocks ideal for peer-to-peer transactions.
 * As of December 2017, the RaiBlocks network has processed over four million transactions with an unpruned ledger size of only 1.7GB.
 
-***
+For more information, see [RaiBlocks.net](https://raiblocks.net/) or read the [RaiBlocks whitepaper](https://raiblocks.net/media/RaiBlocks_Whitepaper__English.pdf). 
 
-### For more information:
-- [Homepage](https://raiblocks.net)
+### Resources
+- [RaiBlocks website](https://raiblocks.net)
 - [Whitepaper](https://raiblocks.net/media/RaiBlocks_Whitepaper__English.pdf)
 - [Roadmap](https://raiblocks.net/media/raiblocks-roadmap-v2-en.png)
-
-***
+- [Discord chat](https://chat.raiblocks.net)
+- [RaiBlocks forum](https://forum.raiblocks.net/)
+- [GitHub wiki](https://github.com/clemahieu/raiblocks/wiki)
 
 ### Build instructions: 
 https://github.com/clemahieu/raiblocks/wiki/Build-Instructions
+
+### Need help?
+- See the documentation at the [RaiBlocks wiki](https://github.com/clemahieu/raiblocks/wiki) for help and more information.
+- Ask for help in the [Discord #development](https://discordapp.com/channels/370266023905198083/370285507185344524) channel.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-RaiBlocks  
-====
+# RaiBlocks  
 [![Build Status](https://travis-ci.org/clemahieu/raiblocks.svg?branch=master)](https://travis-ci.org/clemahieu/raiblocks)
 ![Logo of RaiBlocks](https://github.com/clemahieu/raiblocks/blob/master/logo.png)
 
@@ -8,7 +7,7 @@ RaiBlocks is designed to be a feeless, instant, high throughput cryptocurrency.
 
 We've applied the philosophy of "do one thing and do it well", giving you performance and scalability unmatched by any other platform.
 
-### Key Features:
+### Key features
 * RaiBlocks utilizes a novel block-lattice architecture, unlike conventional blockchains used in many other cryptocurrencies.
 * The network requires minimal resources, no high-power mining hardware, and can process high transaction throughput.
 * Offers feeless, instantaneous transactions, as well as unlimited scalability, making RaiBlocks ideal for peer-to-peer transactions.
@@ -24,12 +23,11 @@ For more information, see [RaiBlocks.net](https://raiblocks.net/) or read the [R
 - [RaiBlocks forum](https://forum.raiblocks.net/)
 - [GitHub wiki](https://github.com/clemahieu/raiblocks/wiki)
 
-### Build instructions: 
+### Build instructions
 https://github.com/clemahieu/raiblocks/wiki/Build-Instructions
 
-### Need help?
-- See the documentation at the [RaiBlocks wiki](https://github.com/clemahieu/raiblocks/wiki) for help and more information.
-- Ask for help in the [Discord #development](https://discordapp.com/channels/370266023905198083/370285507185344524) channel.
+### Want to contribute?
+Please see the [contributors guide](https://github.com/clemahieu/raiblocks/wiki/Contributing).
 
 ### Contact us
 


### PR DESCRIPTION
This pulls from a few other popular cryptocurrency README's by adding a **Resources** section with links to the various available resources, like the Discord chat or the RaiBlocks forum. 

I had several people ask me for instructions on how to run a node so I've added in several links to the wiki, since that's where the bulk of this information can be found right now.
  