### PR TITLE
Replace deep nesting with result short-circuit idiom

### DIFF
--- a/rai/node/common.cpp
+++ b/rai/node/common.cpp
@@ -54,36 +54,18 @@ void rai::message::write_header (rai::stream & stream_a)
 
 bool rai::message::read_header (rai::stream & stream_a, uint8_t & version_max_a, uint8_t & version_using_a, uint8_t & version_min_a, rai::message_type & type_a, std::bitset<16> & extensions_a)
 {
+	uint16_t extensions_l;
 	std::array<uint8_t, 2> magic_number_l;
 	auto result (rai::read (stream_a, magic_number_l));
+	result = result || magic_number_l != magic_number;
+	result = result || rai::read (stream_a, version_max_a);
+	result = result || rai::read (stream_a, version_using_a);
+	result = result || rai::read (stream_a, version_min_a);
+	result = result || rai::read (stream_a, type_a);
+	result = result || rai::read (stream_a, extensions_l);
 	if (!result)
 	{
-		result = magic_number_l != magic_number;
-		if (!result)
-		{
-			result = rai::read (stream_a, version_max_a);
-			if (!result)
-			{
-				result = rai::read (stream_a, version_using_a);
-				if (!result)
-				{
-					result = rai::read (stream_a, version_min_a);
-					if (!result)
-					{
-						result = rai::read (stream_a, type_a);
-						if (!result)
-						{
-							uint16_t extensions_l;
-							result = rai::read (stream_a, extensions_l);
-							if (!result)
-							{
-								extensions_a = extensions_l;
-							}
-						}
-					}
-				}
-			}
-		}
+		extensions_a = extensions_l;
 	}
 	return result;
 }


### PR DESCRIPTION
This PR is a request for discussion regarding deep nesting more than anything else. These pyramids appear a few places.

I find the short-circuit idiom easier to read, and it nicely mirrors the corresponding `write_header` function.

`read_header` was low-hanging fruit (and I assume it's already covered by tests, seems to work fine)