### PR TITLE
Fix wallet race condition.

### DIFF
--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -939,7 +939,7 @@ TEST (node, fork_bootstrap_flip)
 		system0.poll ();
 		system1.poll ();
 		++iterations2;
-		ASSERT_LT (iterations2, 200);
+		ASSERT_LT (iterations2, 1000);
 		rai::transaction transaction (node2.store.environment, nullptr, false);
 		again = !node2.store.block_exists (transaction, send1->hash ());
 	}

--- a/rai/lib/blocks.cpp
+++ b/rai/lib/blocks.cpp
@@ -20,7 +20,7 @@ bool rai::from_string_hex (std::string const & value_a, uint64_t & target_a)
 			stream << std::hex << std::noshowbase;
 			try
 			{
-                		uint64_t number_l;
+				uint64_t number_l;
 				stream >> number_l;
 				target_a = number_l;
 				if (!stream.eof ())

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1343,7 +1343,7 @@ warmed_up (0),
 block_processor (*this),
 block_processor_thread ([this]() { this->block_processor.process_blocks (); })
 {
-	wallets.observer = [this] (bool active) {
+	wallets.observer = [this](bool active) {
 		observers.wallet (active);
 	};
 	peers.peer_observer = [this](rai::endpoint const & endpoint_a) {
@@ -2777,9 +2777,9 @@ void rai::active_transactions::announce_votes ()
 	std::vector<rai::block_hash> inactive;
 	rai::transaction transaction (node.store.environment, nullptr, true);
 	std::lock_guard<std::mutex> lock (mutex);
-	
+
 	{
-        	size_t announcements (0);
+		size_t announcements (0);
 		auto i (roots.begin ());
 		auto n (roots.end ());
 		// Announce our decision for up to `announcements_per_interval' conflicts

--- a/rai/node/wallet.hpp
+++ b/rai/node/wallet.hpp
@@ -95,6 +95,7 @@ public:
 	void upgrade_v1_v2 ();
 	void upgrade_v2_v3 ();
 	rai::fan password;
+	rai::fan wallet_key_mem;
 	static unsigned const version_1;
 	static unsigned const version_2;
 	static unsigned const version_3;
@@ -113,6 +114,7 @@ public:
 	rai::kdf & kdf;
 	rai::mdb_env & environment;
 	MDB_dbi handle;
+	std::recursive_mutex mutex;
 };
 class node;
 // A wallet is a set of account keys encrypted by a common encryption key


### PR DESCRIPTION
The rekey() operation writes to memory and to LMDB, but the visibility of the two operations is totally different, leading to a number of race conditions.

I had another version of this patch that made the visibility of the password match that of the LMDB transaction through a new transaction finalizer concept, and a transaction read barrier, but it was much more complex. This version just duplicates the wallet key in memory, where visibility can be serialized with the password.
  