### PR TITLE
Disable rpc.account_info

### DIFF
--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -2679,8 +2679,9 @@ TEST (rpc, delegators_count)
 	ASSERT_EQ ("2", count);
 }
 
-TEST (rpc, account_info)
+TEST (rpc, DISABLED_account_info)
 {
+    // DISABLED: Fails when timestamp is sampled just prior to tick
 	rai::system system (24000, 1);
 	rai::keypair key;
 	rai::genesis genesis;


### PR DESCRIPTION
We'll revisit this test but disable it for now while stabilizing CI.