### PR TITLE
Fix node.fork_no_vote_quorum and rpc.account_info tests

### DIFF
--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -1057,7 +1057,7 @@ TEST (node, fork_no_vote_quorum)
 	{
 		system.poll ();
 		++iterations;
-		ASSERT_LT (iterations, 200);
+		ASSERT_LT (iterations, 600);
 	}
 	ASSERT_EQ (node1.config.receive_minimum.number (), node1.weight (key1));
 	ASSERT_EQ (node1.config.receive_minimum.number (), node2.weight (key1));

--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -2711,7 +2711,7 @@ TEST (rpc, account_info)
 	std::string balance (response.json.get<std::string> ("balance"));
 	ASSERT_EQ ("100", balance);
 	std::string modified_timestamp (response.json.get<std::string> ("modified_timestamp"));
-	ASSERT_EQ (std::to_string (time), modified_timestamp);
+	ASSERT_TRUE (abs (time - stol (modified_timestamp)) < 5);
 	std::string block_count (response.json.get<std::string> ("block_count"));
 	ASSERT_EQ ("2", block_count);
 }


### PR DESCRIPTION
Fixes 2/3 of the unstable tests for #456. However, `bootstrap_processor.push_diamond` looks like it might be an actual failure.