### PR TITLE
Add balance observer.

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1197,6 +1197,14 @@ void rai::block_processor::process_receive_many (std::deque<rai::block_processor
 		for (auto & i : progress)
 		{
 			node.observers.blocks (i.first, i.second.account, i.second.amount);
+			if (i.second.amount > 0)
+			{
+				node.observers.account_balance (i.second.account, false);
+				if (!i.second.pending_account.is_zero ())
+				{
+					node.observers.account_balance (i.second.pending_account, true);
+				}
+			}
 		}
 	}
 }

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -413,6 +413,7 @@ public:
 	rai::observer_set<std::shared_ptr<rai::block>, rai::account const &, rai::amount const &> blocks;
 	rai::observer_set<bool> wallet;
 	rai::observer_set<std::shared_ptr<rai::vote>, rai::endpoint const &> vote;
+	rai::observer_set<rai::account const &, bool> account_balance;
 	rai::observer_set<rai::endpoint const &> endpoint;
 	rai::observer_set<> disconnect;
 	rai::observer_set<> started;

--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -1048,10 +1048,10 @@ void rai_qt::wallet::start ()
 			this_l->push_main_stack (this_l->send_blocks_window);
 		}
 	});
-	node.observers.blocks.add ([this_w](std::shared_ptr<rai::block>, rai::account const & account_a, rai::amount const &) {
+	node.observers.blocks.add ([this_w](std::shared_ptr<rai::block> block_a, rai::account const & account_a, rai::amount const &) {
 		if (auto this_l = this_w.lock ())
 		{
-			this_l->application.postEvent (&this_l->processor, new eventloop_event ([this_w, account_a]() {
+			this_l->application.postEvent (&this_l->processor, new eventloop_event ([this_w, block_a, account_a]() {
 				if (auto this_l = this_w.lock ())
 				{
 					if (this_l->wallet_m->exists (account_a))
@@ -1061,6 +1061,19 @@ void rai_qt::wallet::start ()
 					if (account_a == this_l->account)
 					{
 						this_l->history.refresh ();
+					}
+				}
+			}));
+		}
+	});
+	node.observers.account_balance.add ([this_w](rai::account const & account_a, bool is_pending) {
+		if (auto this_l = this_w.lock ())
+		{
+			this_l->application.postEvent (&this_l->processor, new eventloop_event ([this_w, account_a]() {
+				if (auto this_l = this_w.lock ())
+				{
+					if (account_a == this_l->account)
+					{
 						this_l->self.refresh_balance ();
 					}
 				}

--- a/rai/secure.cpp
+++ b/rai/secure.cpp
@@ -2411,6 +2411,7 @@ void ledger_processor::send_block (rai::send_block const & block_a)
 						ledger.store.frontier_put (transaction, hash, account);
 						result.account = account;
 						result.amount = amount;
+						result.pending_account = block_a.hashables.destination;
 					}
 				}
 			}

--- a/rai/secure.hpp
+++ b/rai/secure.hpp
@@ -327,6 +327,7 @@ public:
 	rai::process_result code;
 	rai::account account;
 	rai::amount amount;
+	rai::account pending_account;
 };
 enum class tally_result
 {


### PR DESCRIPTION
This fixes an issue where pending balances won't show up until the user triggers a UI refresh some other way.
  