### PR TITLE
Improve exception handling in the daemon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ add_library (secure
 
 SET (RAI_LIB_SOURCES
 	${PLATFORM_LIB_SOURCE}
+	rai/lib/exceptions.hpp
 	rai/lib/blocks.cpp
 	rai/lib/blocks.hpp
 	rai/lib/interface.cpp

--- a/rai/core_test/uint256_union.cpp
+++ b/rai/core_test/uint256_union.cpp
@@ -406,8 +406,7 @@ TEST (json, fetch_object)
 	stream1.close ();
 	rai::open_or_create (stream1, path1.string ());
 	json_upgrade_test object1;
-	auto error1 (rai::fetch_object (object1, path1, stream1));
-	ASSERT_FALSE (error1);
+	ASSERT_NO_THROW (rai::fetch_object (object1, path1, stream1));
 	ASSERT_EQ ("changed", object1.text);
 	boost::property_tree::ptree tree1;
 	stream1.close ();
@@ -417,21 +416,18 @@ TEST (json, fetch_object)
 	std::string string2 ("{ \"thing\": \"junktest2\" }");
 	std::stringstream stream2 (string2);
 	json_upgrade_test object2;
-	auto error2 (rai::fetch_object (object2, stream2));
-	ASSERT_FALSE (error2);
+	ASSERT_NO_THROW (rai::fetch_object (object2, stream2));
 	ASSERT_EQ ("junktest2", object2.text);
 	ASSERT_EQ ("{ \"thing\": \"junktest2\" }", string2);
 	std::string string3 ("{ \"thing\": \"error\" }");
 	std::stringstream stream3 (string3);
 	json_upgrade_test object3;
-	auto error3 (rai::fetch_object (object3, stream3));
-	ASSERT_TRUE (error3);
+	ASSERT_ANY_THROW (rai::fetch_object (object3, stream3));
 	auto path2 (rai::unique_path ());
 	std::fstream stream4;
 	rai::open_or_create (stream4, path2.string ());
 	json_upgrade_test object4;
-	auto error4 (rai::fetch_object (object4, path2, stream4));
-	ASSERT_FALSE (error4);
+	ASSERT_NO_THROW (rai::fetch_object (object4, path2, stream4));
 	ASSERT_EQ ("created", object4.text);
 	boost::property_tree::ptree tree2;
 	stream4.close ();
@@ -445,8 +441,7 @@ TEST (json, DISABLED_fetch_write_fail)
 	std::string string4 ("");
 	std::stringstream stream4 (string4, std::ios_base::in);
 	json_upgrade_test object4;
-	auto error4 (rai::fetch_object (object4, stream4));
-	ASSERT_TRUE (error4);
+	ASSERT_NO_THROW (rai::fetch_object (object4, stream4));
 }
 
 TEST (uint64_t, parse)

--- a/rai/lib/exceptions.hpp
+++ b/rai/lib/exceptions.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace rai
+{
+/**
+ * Thrown if there's a problem with parsing the configuration file.
+ * At a minimum, this exception should be caught in user facing
+ * code, such as the CLI, with proper error reporting to the user.
+ */
+class config_error : public std::runtime_error
+{
+public:
+	config_error (std::string msg) :
+	std::runtime_error (msg)
+	{
+	}
+};
+}

--- a/rai/rai_node/daemon.hpp
+++ b/rai/rai_node/daemon.hpp
@@ -6,6 +6,10 @@ namespace rai_daemon
 class daemon
 {
 public:
+	/**
+	 * Start node in daemon mode
+	 * @throws rai::config_error Throwm if the config file cannot be parsed
+	 */
 	void run (boost::filesystem::path const &);
 };
 class daemon_config
@@ -14,7 +18,7 @@ public:
 	daemon_config (boost::filesystem::path const &);
 	bool deserialize_json (bool &, boost::property_tree::ptree &);
 	void serialize_json (boost::property_tree::ptree &);
-	bool upgrade_json (unsigned, boost::property_tree::ptree &);
+	void upgrade_json (unsigned, boost::property_tree::ptree &);
 	bool rpc_enable;
 	rai::rpc_config rpc;
 	rai::node_config node;

--- a/rai/rai_node/entry.cpp
+++ b/rai/rai_node/entry.cpp
@@ -1,8 +1,8 @@
+#include <argon2.h>
+#include <rai/lib/exceptions.hpp>
 #include <rai/node/node.hpp>
 #include <rai/node/testing.hpp>
 #include <rai/rai_node/daemon.hpp>
-
-#include <argon2.h>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
@@ -109,380 +109,390 @@ void fill_zero (void * data)
 
 int main (int argc, char * const * argv)
 {
-	boost::program_options::options_description description ("Command line options");
-	rai::add_node_options (description);
-
-	// clang-format off
-	description.add_options ()
-		("help", "Print out options")
-		("daemon", "Start node daemon")
-		("debug_block_count", "Display the number of block")
-		("debug_bootstrap_generate", "Generate bootstrap sequence of blocks")
-		("debug_dump_representatives", "List representatives and weights")
-		("debug_frontier_count", "Display the number of accounts")
-		("debug_mass_activity", "Generates fake debug activity")
-		("debug_profile_generate", "Profile work generation")
-		("debug_opencl", "OpenCL work generation")
-		("debug_profile_verify", "Profile work verification")
-		("debug_profile_kdf", "Profile kdf function")
-		("debug_verify_profile", "Profile signature verification")
-		("debug_profile_sign", "Profile signature generation")
-		("debug_xorshift_profile", "Profile xorshift algorithms")
-		("platform", boost::program_options::value<std::string> (), "Defines the <platform> for OpenCL commands")
-		("device", boost::program_options::value<std::string> (), "Defines <device> for OpenCL command")
-		("threads", boost::program_options::value<std::string> (), "Defines <threads> count for OpenCL command");
-	// clang-format on
-
-	boost::program_options::variables_map vm;
-	boost::program_options::store (boost::program_options::parse_command_line (argc, argv, description), vm);
-	boost::program_options::notify (vm);
 	int result (0);
-	if (!rai::handle_node_options (vm))
+
+	try
 	{
-	}
-	else if (vm.count ("daemon") > 0)
-	{
-		boost::filesystem::path data_path;
-		if (vm.count ("data_path"))
+		boost::program_options::options_description description ("Command line options");
+		rai::add_node_options (description);
+
+		// clang-format off
+        description.add_options ()
+                ("help", "Print out options")
+                ("daemon", "Start node daemon")
+                ("debug_block_count", "Display the number of block")
+                ("debug_bootstrap_generate", "Generate bootstrap sequence of blocks")
+                ("debug_dump_representatives", "List representatives and weights")
+                ("debug_frontier_count", "Display the number of accounts")
+                ("debug_mass_activity", "Generates fake debug activity")
+                ("debug_profile_generate", "Profile work generation")
+                ("debug_opencl", "OpenCL work generation")
+                ("debug_profile_verify", "Profile work verification")
+                ("debug_profile_kdf", "Profile kdf function")
+                ("debug_verify_profile", "Profile signature verification")
+                ("debug_profile_sign", "Profile signature generation")
+                ("debug_xorshift_profile", "Profile xorshift algorithms")
+                ("platform", boost::program_options::value<std::string> (), "Defines the <platform> for OpenCL commands")
+                ("device", boost::program_options::value<std::string> (), "Defines <device> for OpenCL command")
+                ("threads", boost::program_options::value<std::string> (), "Defines <threads> count for OpenCL command");
+		// clang-format on
+
+		boost::program_options::variables_map vm;
+		boost::program_options::store (boost::program_options::parse_command_line (argc, argv, description), vm);
+		boost::program_options::notify (vm);
+
+		if (!rai::handle_node_options (vm))
 		{
-			data_path = boost::filesystem::path (vm["data_path"].as<std::string> ());
 		}
-		else
+		else if (vm.count ("daemon") > 0)
 		{
-			data_path = rai::working_path ();
-		}
-		rai_daemon::daemon daemon;
-		daemon.run (data_path);
-	}
-	else if (vm.count ("debug_block_count"))
-	{
-		rai::inactive_node node;
-		rai::transaction transaction (node.node->store.environment, nullptr, false);
-		std::cout << boost::str (boost::format ("Block count: %1%\n") % node.node->store.block_count (transaction).sum ());
-	}
-	else if (vm.count ("debug_bootstrap_generate"))
-	{
-		if (vm.count ("key") == 1)
-		{
-			rai::uint256_union key;
-			if (!key.decode_hex (vm["key"].as<std::string> ()))
+			boost::filesystem::path data_path;
+			if (vm.count ("data_path"))
 			{
-				rai::keypair genesis (key.to_string ());
-				rai::work_pool work (std::numeric_limits<unsigned>::max (), nullptr);
-				std::cout << "Genesis: " << genesis.prv.data.to_string () << std::endl
-				          << "Public: " << genesis.pub.to_string () << std::endl
-				          << "Account: " << genesis.pub.to_account () << std::endl;
-				rai::keypair landing;
-				std::cout << "Landing: " << landing.prv.data.to_string () << std::endl
-				          << "Public: " << landing.pub.to_string () << std::endl
-				          << "Account: " << landing.pub.to_account () << std::endl;
-				for (auto i (0); i != 32; ++i)
+				data_path = boost::filesystem::path (vm["data_path"].as<std::string> ());
+			}
+			else
+			{
+				data_path = rai::working_path ();
+			}
+			rai_daemon::daemon daemon;
+			daemon.run (data_path);
+		}
+		else if (vm.count ("debug_block_count"))
+		{
+			rai::inactive_node node;
+			rai::transaction transaction (node.node->store.environment, nullptr, false);
+			std::cout << boost::str (boost::format ("Block count: %1%\n") % node.node->store.block_count (transaction).sum ());
+		}
+		else if (vm.count ("debug_bootstrap_generate"))
+		{
+			if (vm.count ("key") == 1)
+			{
+				rai::uint256_union key;
+				if (!key.decode_hex (vm["key"].as<std::string> ()))
 				{
-					rai::keypair rep;
-					std::cout << "Rep" << i << ": " << rep.prv.data.to_string () << std::endl
-					          << "Public: " << rep.pub.to_string () << std::endl
-					          << "Account: " << rep.pub.to_account () << std::endl;
-				}
-				rai::uint128_t balance (std::numeric_limits<rai::uint128_t>::max ());
-				rai::open_block genesis_block (genesis.pub, genesis.pub, genesis.pub, genesis.prv, genesis.pub, work.generate (genesis.pub));
-				std::cout << genesis_block.to_json ();
-				rai::block_hash previous (genesis_block.hash ());
-				for (auto i (0); i != 8; ++i)
-				{
-					rai::uint128_t yearly_distribution (rai::uint128_t (1) << (127 - (i == 7 ? 6 : i)));
-					auto weekly_distribution (yearly_distribution / 52);
-					for (auto j (0); j != 52; ++j)
+					rai::keypair genesis (key.to_string ());
+					rai::work_pool work (std::numeric_limits<unsigned>::max (), nullptr);
+					std::cout << "Genesis: " << genesis.prv.data.to_string () << std::endl
+					          << "Public: " << genesis.pub.to_string () << std::endl
+					          << "Account: " << genesis.pub.to_account () << std::endl;
+					rai::keypair landing;
+					std::cout << "Landing: " << landing.prv.data.to_string () << std::endl
+					          << "Public: " << landing.pub.to_string () << std::endl
+					          << "Account: " << landing.pub.to_account () << std::endl;
+					for (auto i (0); i != 32; ++i)
 					{
-						assert (balance > weekly_distribution);
-						balance = balance < (weekly_distribution * 2) ? 0 : balance - weekly_distribution;
-						rai::send_block send (previous, landing.pub, balance, genesis.prv, genesis.pub, work.generate (previous));
-						previous = send.hash ();
-						std::cout << send.to_json ();
-						std::cout.flush ();
+						rai::keypair rep;
+						std::cout << "Rep" << i << ": " << rep.prv.data.to_string () << std::endl
+						          << "Public: " << rep.pub.to_string () << std::endl
+						          << "Account: " << rep.pub.to_account () << std::endl;
+					}
+					rai::uint128_t balance (std::numeric_limits<rai::uint128_t>::max ());
+					rai::open_block genesis_block (genesis.pub, genesis.pub, genesis.pub, genesis.prv, genesis.pub, work.generate (genesis.pub));
+					std::cout << genesis_block.to_json ();
+					rai::block_hash previous (genesis_block.hash ());
+					for (auto i (0); i != 8; ++i)
+					{
+						rai::uint128_t yearly_distribution (rai::uint128_t (1) << (127 - (i == 7 ? 6 : i)));
+						auto weekly_distribution (yearly_distribution / 52);
+						for (auto j (0); j != 52; ++j)
+						{
+							assert (balance > weekly_distribution);
+							balance = balance < (weekly_distribution * 2) ? 0 : balance - weekly_distribution;
+							rai::send_block send (previous, landing.pub, balance, genesis.prv, genesis.pub, work.generate (previous));
+							previous = send.hash ();
+							std::cout << send.to_json ();
+							std::cout.flush ();
+						}
+					}
+				}
+				else
+				{
+					std::cerr << "Invalid key\n";
+					result = -1;
+				}
+			}
+			else
+			{
+				std::cerr << "Bootstrapping requires one <key> option\n";
+				result = -1;
+			}
+		}
+		else if (vm.count ("debug_dump_representatives"))
+		{
+			rai::inactive_node node;
+			rai::transaction transaction (node.node->store.environment, nullptr, false);
+			rai::uint128_t total;
+			for (auto i (node.node->store.representation_begin (transaction)), n (node.node->store.representation_end ()); i != n; ++i)
+			{
+				rai::account account (i->first.uint256 ());
+				auto amount (node.node->store.representation_get (transaction, account));
+				total += amount;
+				std::cout << boost::str (boost::format ("%1% %2% %3%\n") % account.to_account () % amount.convert_to<std::string> () % total.convert_to<std::string> ());
+			}
+			std::map<rai::account, rai::uint128_t> calculated;
+			for (auto i (node.node->store.latest_begin (transaction)), n (node.node->store.latest_end ()); i != n; ++i)
+			{
+				rai::account account (i->first.uint256 ());
+				rai::account_info info (i->second);
+				rai::block_hash rep_block (node.node->ledger.representative_calculated (transaction, info.head));
+				std::unique_ptr<rai::block> block (node.node->store.block_get (transaction, rep_block));
+				calculated[block->representative ()] += info.balance.number ();
+			}
+			total = 0;
+			for (auto i (calculated.begin ()), n (calculated.end ()); i != n; ++i)
+			{
+				total += i->second;
+				std::cout << boost::str (boost::format ("%1% %2% %3%\n") % i->first.to_account () % i->second.convert_to<std::string> () % total.convert_to<std::string> ());
+			}
+		}
+		else if (vm.count ("debug_frontier_count"))
+		{
+			rai::inactive_node node;
+			rai::transaction transaction (node.node->store.environment, nullptr, false);
+			std::cout << boost::str (boost::format ("Frontier count: %1%\n") % node.node->store.frontier_count (transaction));
+		}
+		else if (vm.count ("debug_mass_activity"))
+		{
+			rai::system system (24000, 1);
+			size_t count (1000000);
+			system.generate_mass_activity (count, *system.nodes[0]);
+		}
+		else if (vm.count ("debug_profile_kdf"))
+		{
+			rai::uint256_union result;
+			rai::uint256_union salt (0);
+			std::string password ("");
+			for (; true;)
+			{
+				auto begin1 (std::chrono::high_resolution_clock::now ());
+				auto success (argon2_hash (1, rai::wallet_store::kdf_work, 1, password.data (), password.size (), salt.bytes.data (), salt.bytes.size (), result.bytes.data (), result.bytes.size (), NULL, 0, Argon2_d, 0x10));
+				auto end1 (std::chrono::high_resolution_clock::now ());
+				std::cerr << boost::str (boost::format ("Derivation time: %1%us\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
+			}
+		}
+		else if (vm.count ("debug_profile_generate"))
+		{
+			rai::work_pool work (std::numeric_limits<unsigned>::max (), nullptr);
+			rai::change_block block (0, 0, rai::keypair ().prv, 0, 0);
+			std::cerr << "Starting generation profiling\n";
+			for (uint64_t i (0); true; ++i)
+			{
+				block.hashables.previous.qwords[0] += 1;
+				auto begin1 (std::chrono::high_resolution_clock::now ());
+				block.block_work_set (work.generate (block.root ()));
+				auto end1 (std::chrono::high_resolution_clock::now ());
+				std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
+			}
+		}
+		else if (vm.count ("debug_opencl"))
+		{
+			bool error (false);
+			rai::opencl_environment environment (error);
+			if (!error)
+			{
+				unsigned short platform (0);
+				if (vm.count ("platform") == 1)
+				{
+					try
+					{
+						platform = boost::lexical_cast<unsigned short> (vm["platform"].as<std::string> ());
+					}
+					catch (boost::bad_lexical_cast & e)
+					{
+						std::cerr << "Invalid platform id\n";
+						result = -1;
+					}
+				}
+				unsigned short device (0);
+				if (vm.count ("device") == 1)
+				{
+					try
+					{
+						device = boost::lexical_cast<unsigned short> (vm["device"].as<std::string> ());
+					}
+					catch (boost::bad_lexical_cast & e)
+					{
+						std::cerr << "Invalid device id\n";
+						result = -1;
+					}
+				}
+				unsigned threads (1024 * 1024);
+				if (vm.count ("threads") == 1)
+				{
+					try
+					{
+						threads = boost::lexical_cast<unsigned> (vm["threads"].as<std::string> ());
+					}
+					catch (boost::bad_lexical_cast & e)
+					{
+						std::cerr << "Invalid threads count\n";
+						result = -1;
+					}
+				}
+				if (!result)
+				{
+					error |= platform >= environment.platforms.size ();
+					if (!error)
+					{
+						error |= device >= environment.platforms[platform].devices.size ();
+						if (!error)
+						{
+							rai::logging logging;
+							auto opencl (rai::opencl_work::create (true, { platform, device, threads }, logging));
+							rai::work_pool work_pool (std::numeric_limits<unsigned>::max (), opencl ? [&opencl](rai::uint256_union const & root_a) {
+								return opencl->generate_work (root_a);
+							}
+							                                                                        : std::function<boost::optional<uint64_t> (rai::uint256_union const &)> (nullptr));
+							rai::change_block block (0, 0, rai::keypair ().prv, 0, 0);
+							std::cerr << boost::str (boost::format ("Starting OpenCL generation profiling. Platform: %1%. Device: %2%. Threads: %3%\n") % platform % device % threads);
+							for (uint64_t i (0); true; ++i)
+							{
+								block.hashables.previous.qwords[0] += 1;
+								auto begin1 (std::chrono::high_resolution_clock::now ());
+								block.block_work_set (work_pool.generate (block.root ()));
+								auto end1 (std::chrono::high_resolution_clock::now ());
+								std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
+							}
+						}
+						else
+						{
+							std::cout << "Not available device id\n"
+							          << std::endl;
+							result = -1;
+						}
+					}
+					else
+					{
+						std::cout << "Not available platform id\n"
+						          << std::endl;
+						result = -1;
 					}
 				}
 			}
 			else
 			{
-				std::cerr << "Invalid key\n";
+				std::cout << "Error initializing OpenCL" << std::endl;
 				result = -1;
 			}
 		}
-		else
+		else if (vm.count ("debug_profile_verify"))
 		{
-			std::cerr << "Bootstrapping requires one <key> option\n";
-			result = -1;
-		}
-	}
-	else if (vm.count ("debug_dump_representatives"))
-	{
-		rai::inactive_node node;
-		rai::transaction transaction (node.node->store.environment, nullptr, false);
-		rai::uint128_t total;
-		for (auto i (node.node->store.representation_begin (transaction)), n (node.node->store.representation_end ()); i != n; ++i)
-		{
-			rai::account account (i->first.uint256 ());
-			auto amount (node.node->store.representation_get (transaction, account));
-			total += amount;
-			std::cout << boost::str (boost::format ("%1% %2% %3%\n") % account.to_account () % amount.convert_to<std::string> () % total.convert_to<std::string> ());
-		}
-		std::map<rai::account, rai::uint128_t> calculated;
-		for (auto i (node.node->store.latest_begin (transaction)), n (node.node->store.latest_end ()); i != n; ++i)
-		{
-			rai::account account (i->first.uint256 ());
-			rai::account_info info (i->second);
-			rai::block_hash rep_block (node.node->ledger.representative_calculated (transaction, info.head));
-			std::unique_ptr<rai::block> block (node.node->store.block_get (transaction, rep_block));
-			calculated[block->representative ()] += info.balance.number ();
-		}
-		total = 0;
-		for (auto i (calculated.begin ()), n (calculated.end ()); i != n; ++i)
-		{
-			total += i->second;
-			std::cout << boost::str (boost::format ("%1% %2% %3%\n") % i->first.to_account () % i->second.convert_to<std::string> () % total.convert_to<std::string> ());
-		}
-	}
-	else if (vm.count ("debug_frontier_count"))
-	{
-		rai::inactive_node node;
-		rai::transaction transaction (node.node->store.environment, nullptr, false);
-		std::cout << boost::str (boost::format ("Frontier count: %1%\n") % node.node->store.frontier_count (transaction));
-	}
-	else if (vm.count ("debug_mass_activity"))
-	{
-		rai::system system (24000, 1);
-		size_t count (1000000);
-		system.generate_mass_activity (count, *system.nodes[0]);
-	}
-	else if (vm.count ("debug_profile_kdf"))
-	{
-		rai::uint256_union result;
-		rai::uint256_union salt (0);
-		std::string password ("");
-		for (; true;)
-		{
-			auto begin1 (std::chrono::high_resolution_clock::now ());
-			auto success (argon2_hash (1, rai::wallet_store::kdf_work, 1, password.data (), password.size (), salt.bytes.data (), salt.bytes.size (), result.bytes.data (), result.bytes.size (), NULL, 0, Argon2_d, 0x10));
-			auto end1 (std::chrono::high_resolution_clock::now ());
-			std::cerr << boost::str (boost::format ("Derivation time: %1%us\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
-		}
-	}
-	else if (vm.count ("debug_profile_generate"))
-	{
-		rai::work_pool work (std::numeric_limits<unsigned>::max (), nullptr);
-		rai::change_block block (0, 0, rai::keypair ().prv, 0, 0);
-		std::cerr << "Starting generation profiling\n";
-		for (uint64_t i (0); true; ++i)
-		{
-			block.hashables.previous.qwords[0] += 1;
-			auto begin1 (std::chrono::high_resolution_clock::now ());
-			block.block_work_set (work.generate (block.root ()));
-			auto end1 (std::chrono::high_resolution_clock::now ());
-			std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
-		}
-	}
-	else if (vm.count ("debug_opencl"))
-	{
-		bool error (false);
-		rai::opencl_environment environment (error);
-		if (!error)
-		{
-			unsigned short platform (0);
-			if (vm.count ("platform") == 1)
-			{
-				try
-				{
-					platform = boost::lexical_cast<unsigned short> (vm["platform"].as<std::string> ());
-				}
-				catch (boost::bad_lexical_cast & e)
-				{
-					std::cerr << "Invalid platform id\n";
-					result = -1;
-				}
-			}
-			unsigned short device (0);
-			if (vm.count ("device") == 1)
-			{
-				try
-				{
-					device = boost::lexical_cast<unsigned short> (vm["device"].as<std::string> ());
-				}
-				catch (boost::bad_lexical_cast & e)
-				{
-					std::cerr << "Invalid device id\n";
-					result = -1;
-				}
-			}
-			unsigned threads (1024 * 1024);
-			if (vm.count ("threads") == 1)
-			{
-				try
-				{
-					threads = boost::lexical_cast<unsigned> (vm["threads"].as<std::string> ());
-				}
-				catch (boost::bad_lexical_cast & e)
-				{
-					std::cerr << "Invalid threads count\n";
-					result = -1;
-				}
-			}
-			if (!result)
-			{
-				error |= platform >= environment.platforms.size ();
-				if (!error)
-				{
-					error |= device >= environment.platforms[platform].devices.size ();
-					if (!error)
-					{
-						rai::logging logging;
-						auto opencl (rai::opencl_work::create (true, { platform, device, threads }, logging));
-						rai::work_pool work_pool (std::numeric_limits<unsigned>::max (), opencl ? [&opencl](rai::uint256_union const & root_a) {
-							return opencl->generate_work (root_a);
-						}
-						                                                                        : std::function<boost::optional<uint64_t> (rai::uint256_union const &)> (nullptr));
-						rai::change_block block (0, 0, rai::keypair ().prv, 0, 0);
-						std::cerr << boost::str (boost::format ("Starting OpenCL generation profiling. Platform: %1%. Device: %2%. Threads: %3%\n") % platform % device % threads);
-						for (uint64_t i (0); true; ++i)
-						{
-							block.hashables.previous.qwords[0] += 1;
-							auto begin1 (std::chrono::high_resolution_clock::now ());
-							block.block_work_set (work_pool.generate (block.root ()));
-							auto end1 (std::chrono::high_resolution_clock::now ());
-							std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
-						}
-					}
-					else
-					{
-						std::cout << "Not available device id\n"
-						          << std::endl;
-						result = -1;
-					}
-				}
-				else
-				{
-					std::cout << "Not available platform id\n"
-					          << std::endl;
-					result = -1;
-				}
-			}
-		}
-		else
-		{
-			std::cout << "Error initializing OpenCL" << std::endl;
-			result = -1;
-		}
-	}
-	else if (vm.count ("debug_profile_verify"))
-	{
-		rai::work_pool work (std::numeric_limits<unsigned>::max (), nullptr);
-		rai::change_block block (0, 0, rai::keypair ().prv, 0, 0);
-		std::cerr << "Starting verification profiling\n";
-		for (uint64_t i (0); true; ++i)
-		{
-			block.hashables.previous.qwords[0] += 1;
-			auto begin1 (std::chrono::high_resolution_clock::now ());
-			for (uint64_t t (0); t < 1000000; ++t)
+			rai::work_pool work (std::numeric_limits<unsigned>::max (), nullptr);
+			rai::change_block block (0, 0, rai::keypair ().prv, 0, 0);
+			std::cerr << "Starting verification profiling\n";
+			for (uint64_t i (0); true; ++i)
 			{
 				block.hashables.previous.qwords[0] += 1;
-				block.block_work_set (t);
-				rai::work_validate (block);
+				auto begin1 (std::chrono::high_resolution_clock::now ());
+				for (uint64_t t (0); t < 1000000; ++t)
+				{
+					block.hashables.previous.qwords[0] += 1;
+					block.block_work_set (t);
+					rai::work_validate (block);
+				}
+				auto end1 (std::chrono::high_resolution_clock::now ());
+				std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
 			}
-			auto end1 (std::chrono::high_resolution_clock::now ());
-			std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
 		}
-	}
-	else if (vm.count ("debug_verify_profile"))
-	{
-		rai::keypair key;
-		rai::uint256_union message;
-		rai::uint512_union signature;
-		signature = rai::sign_message (key.prv, key.pub, message);
-		auto begin (std::chrono::high_resolution_clock::now ());
-		for (auto i (0u); i < 1000; ++i)
-		{
-			rai::validate_message (key.pub, message, signature);
-		}
-		auto end (std::chrono::high_resolution_clock::now ());
-		std::cerr << "Signature verifications " << std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count () << std::endl;
-	}
-	else if (vm.count ("debug_profile_sign"))
-	{
-		std::cerr << "Starting blocks signing profiling\n";
-		for (uint64_t i (0); true; ++i)
+		else if (vm.count ("debug_verify_profile"))
 		{
 			rai::keypair key;
-			rai::block_hash latest (0);
-			auto begin1 (std::chrono::high_resolution_clock::now ());
-			for (uint64_t balance (0); balance < 1000; ++balance)
+			rai::uint256_union message;
+			rai::uint512_union signature;
+			signature = rai::sign_message (key.prv, key.pub, message);
+			auto begin (std::chrono::high_resolution_clock::now ());
+			for (auto i (0u); i < 1000; ++i)
 			{
-				rai::send_block send (latest, key.pub, balance, key.prv, key.pub, 0);
-				latest = send.hash ();
+				rai::validate_message (key.pub, message, signature);
 			}
-			auto end1 (std::chrono::high_resolution_clock::now ());
-			std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
+			auto end (std::chrono::high_resolution_clock::now ());
+			std::cerr << "Signature verifications " << std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count () << std::endl;
 		}
-	}
+		else if (vm.count ("debug_profile_sign"))
+		{
+			std::cerr << "Starting blocks signing profiling\n";
+			for (uint64_t i (0); true; ++i)
+			{
+				rai::keypair key;
+				rai::block_hash latest (0);
+				auto begin1 (std::chrono::high_resolution_clock::now ());
+				for (uint64_t balance (0); balance < 1000; ++balance)
+				{
+					rai::send_block send (latest, key.pub, balance, key.prv, key.pub, 0);
+					latest = send.hash ();
+				}
+				auto end1 (std::chrono::high_resolution_clock::now ());
+				std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
+			}
+		}
 #if 0
-	else if (vm.count ("debug_xorshift_profile"))
-	{
-		auto unaligned (new uint8_t [64 * 1024 * 1024 + 16]);
-		auto aligned (reinterpret_cast <void *> (reinterpret_cast <uintptr_t> (unaligned) & ~uintptr_t (0xfu)));
+		else if (vm.count ("debug_xorshift_profile"))
 		{
-			memset (aligned, 0x0, 64 * 1024 * 1024);
-			auto begin (std::chrono::high_resolution_clock::now ());
-			for (auto i (0u); i < 1000; ++i)
+			auto unaligned (new uint8_t [64 * 1024 * 1024 + 16]);
+			auto aligned (reinterpret_cast <void *> (reinterpret_cast <uintptr_t> (unaligned) & ~uintptr_t (0xfu)));
 			{
-				fill_zero (aligned);
+				memset (aligned, 0x0, 64 * 1024 * 1024);
+				auto begin (std::chrono::high_resolution_clock::now ());
+				for (auto i (0u); i < 1000; ++i)
+				{
+					fill_zero (aligned);
+				}
+				auto end (std::chrono::high_resolution_clock::now ());
+				std::cerr << "Memset " << std::chrono::duration_cast <std::chrono::microseconds> (end - begin).count () << std::endl;
 			}
-			auto end (std::chrono::high_resolution_clock::now ());
-			std::cerr << "Memset " << std::chrono::duration_cast <std::chrono::microseconds> (end - begin).count () << std::endl;
-		}
-		{
-			memset (aligned, 0x0, 64 * 1024 * 1024);
-			auto begin (std::chrono::high_resolution_clock::now ());
-			for (auto i (0u); i < 1000; ++i)
 			{
-				fill_128_reference (aligned);
+				memset (aligned, 0x0, 64 * 1024 * 1024);
+				auto begin (std::chrono::high_resolution_clock::now ());
+				for (auto i (0u); i < 1000; ++i)
+				{
+					fill_128_reference (aligned);
+				}
+				auto end (std::chrono::high_resolution_clock::now ());
+				std::cerr << "Ref fill 128 " << std::chrono::duration_cast <std::chrono::microseconds> (end - begin).count () << std::endl;
 			}
-			auto end (std::chrono::high_resolution_clock::now ());
-			std::cerr << "Ref fill 128 " << std::chrono::duration_cast <std::chrono::microseconds> (end - begin).count () << std::endl;
-		}
-		{
-			memset (aligned, 0x0, 64 * 1024 * 1024);
-			auto begin (std::chrono::high_resolution_clock::now ());
-			for (auto i (0u); i < 1000; ++i)
 			{
-				fill_1024_reference (aligned);
+				memset (aligned, 0x0, 64 * 1024 * 1024);
+				auto begin (std::chrono::high_resolution_clock::now ());
+				for (auto i (0u); i < 1000; ++i)
+				{
+					fill_1024_reference (aligned);
+				}
+				auto end (std::chrono::high_resolution_clock::now ());
+				std::cerr << "Ref fill 1024 " << std::chrono::duration_cast <std::chrono::microseconds> (end - begin).count () << std::endl;
 			}
-			auto end (std::chrono::high_resolution_clock::now ());
-			std::cerr << "Ref fill 1024 " << std::chrono::duration_cast <std::chrono::microseconds> (end - begin).count () << std::endl;
-		}
-		{
-			memset (aligned, 0x0, 64 * 1024 * 1024);
-			auto begin (std::chrono::high_resolution_clock::now ());
-			for (auto i (0u); i < 1000; ++i)
 			{
-				fill_128_sse (aligned);
+				memset (aligned, 0x0, 64 * 1024 * 1024);
+				auto begin (std::chrono::high_resolution_clock::now ());
+				for (auto i (0u); i < 1000; ++i)
+				{
+					fill_128_sse (aligned);
+				}
+				auto end (std::chrono::high_resolution_clock::now ());
+				std::cerr << "SSE fill 128 " << std::chrono::duration_cast <std::chrono::microseconds> (end - begin).count () << std::endl;
 			}
-			auto end (std::chrono::high_resolution_clock::now ());
-			std::cerr << "SSE fill 128 " << std::chrono::duration_cast <std::chrono::microseconds> (end - begin).count () << std::endl;
-		}
-		{
-			memset (aligned, 0x0, 64 * 1024 * 1024);
-			auto begin (std::chrono::high_resolution_clock::now ());
-			for (auto i (0u); i < 1000; ++i)
 			{
-				fill_1024_sse (aligned);
+				memset (aligned, 0x0, 64 * 1024 * 1024);
+				auto begin (std::chrono::high_resolution_clock::now ());
+				for (auto i (0u); i < 1000; ++i)
+				{
+					fill_1024_sse (aligned);
+				}
+				auto end (std::chrono::high_resolution_clock::now ());
+				std::cerr << "SSE fill 1024 " << std::chrono::duration_cast <std::chrono::microseconds> (end - begin).count () << std::endl;
 			}
-			auto end (std::chrono::high_resolution_clock::now ());
-			std::cerr << "SSE fill 1024 " << std::chrono::duration_cast <std::chrono::microseconds> (end - begin).count () << std::endl;
 		}
-	}
 #endif // 0
-	else
-	{
-		std::cout << description << std::endl;
-		result = -1;
+		else
+		{
+			std::cout << description << std::endl;
+			result = -1;
+		}
 	}
+	catch (rai::config_error const & err)
+	{
+		std::cout << "Configuration error: " << err.what () << std::endl;
+	}
+
 	return result;
 }


### PR DESCRIPTION
I wanted to back up the #446 exception discussion with a PR.

While there aren't really many changes, the diff looks like that since there's wrapping of code into try/catch blocks.

It solves a real problem I've been having: misconfigurations/typos in config.json causes daemon startup to fail, but with no clues as to what might be wrong.

The cause of errors while parsing the config file is lost when turning runtime_error into error flags. @Dekoze mentions a similar problem in https://github.com/clemahieu/raiblocks/issues/446

If I mistype something in config.json, I now get a message like `Configuration error: Invalid json in 'rpc'` The precision can be improved further, but it's a start.

I'm proposing the introduction of rai/lib/exceptions.hpp, where we can define exception types, making it easy to do exception-specific error handling. They should all inherit from runtime_error, allowing catch-all when it makes sense.

Finally, this PR ties into https://github.com/clemahieu/raiblocks/pull/479, as I've documented the exceptions with `@throws` doxygen annotations.