### PR TITLE
Override clang format for program options

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2941,7 +2941,33 @@ void rai::thread_runner::join ()
 
 void rai::add_node_options (boost::program_options::options_description & description_a)
 {
-	description_a.add_options () ("account_create", "Insert next deterministic key in to <wallet>") ("account_get", "Get account number for the <key>") ("account_key", "Get the public key for <account>") ("vacuum", "Compact database. If data_path is missing, the database in data directory is compacted.") ("data_path", boost::program_options::value<std::string> (), "Use the supplied path as the data directory") ("diagnostics", "Run internal diagnostics") ("key_create", "Generates a adhoc random keypair and prints it to stdout") ("key_expand", "Derive public key and account number from <key>") ("wallet_add_adhoc", "Insert <key> in to <wallet>") ("wallet_create", "Creates a new wallet and prints the ID") ("wallet_change_seed", "Changes seed for <wallet> to <key>") ("wallet_decrypt_unsafe", "Decrypts <wallet> using <password>, !!THIS WILL PRINT YOUR PRIVATE KEY TO STDOUT!!") ("wallet_destroy", "Destroys <wallet> and all keys it contains") ("wallet_import", "Imports keys in <file> using <password> in to <wallet>") ("wallet_list", "Dumps wallet IDs and public keys") ("wallet_remove", "Remove <account> from <wallet>") ("wallet_representative_get", "Prints default representative for <wallet>") ("wallet_representative_set", "Set <account> as default representative for <wallet>") ("vote_dump", "Dump most recent votes from representatives") ("account", boost::program_options::value<std::string> (), "Defines <account> for other commands") ("file", boost::program_options::value<std::string> (), "Defines <file> for other commands") ("key", boost::program_options::value<std::string> (), "Defines the <key> for other commands, hex") ("password", boost::program_options::value<std::string> (), "Defines <password> for other commands") ("wallet", boost::program_options::value<std::string> (), "Defines <wallet> for other commands");
+	// clang-format off
+	description_a.add_options ()
+		("account_create", "Insert next deterministic key in to <wallet>")
+		("account_get", "Get account number for the <key>")
+		("account_key", "Get the public key for <account>")
+		("vacuum", "Compact database. If data_path is missing, the database in data directory is compacted.")
+		("data_path", boost::program_options::value<std::string> (), "Use the supplied path as the data directory")
+		("diagnostics", "Run internal diagnostics")
+		("key_create", "Generates a adhoc random keypair and prints it to stdout")
+		("key_expand", "Derive public key and account number from <key>")
+		("wallet_add_adhoc", "Insert <key> in to <wallet>")
+		("wallet_create", "Creates a new wallet and prints the ID")
+		("wallet_change_seed", "Changes seed for <wallet> to <key>")
+		("wallet_decrypt_unsafe", "Decrypts <wallet> using <password>, !!THIS WILL PRINT YOUR PRIVATE KEY TO STDOUT!!")
+		("wallet_destroy", "Destroys <wallet> and all keys it contains")
+		("wallet_import", "Imports keys in <file> using <password> in to <wallet>")
+		("wallet_list", "Dumps wallet IDs and public keys")
+		("wallet_remove", "Remove <account> from <wallet>")
+		("wallet_representative_get", "Prints default representative for <wallet>")
+		("wallet_representative_set", "Set <account> as default representative for <wallet>")
+		("vote_dump", "Dump most recent votes from representatives")
+		("account", boost::program_options::value<std::string> (), "Defines <account> for other commands")
+		("file", boost::program_options::value<std::string> (), "Defines <file> for other commands")
+		("key", boost::program_options::value<std::string> (), "Defines the <key> for other commands, hex")
+		("password", boost::program_options::value<std::string> (), "Defines <password> for other commands")
+		("wallet", boost::program_options::value<std::string> (), "Defines <wallet> for other commands");
+	// clang-format on
 }
 
 bool rai::handle_node_options (boost::program_options::variables_map & vm)

--- a/rai/rai_node/entry.cpp
+++ b/rai/rai_node/entry.cpp
@@ -111,7 +111,28 @@ int main (int argc, char * const * argv)
 {
 	boost::program_options::options_description description ("Command line options");
 	rai::add_node_options (description);
-	description.add_options () ("help", "Print out options") ("daemon", "Start node daemon") ("debug_block_count", "Display the number of block") ("debug_bootstrap_generate", "Generate bootstrap sequence of blocks") ("debug_dump_representatives", "List representatives and weights") ("debug_frontier_count", "Display the number of accounts") ("debug_mass_activity", "Generates fake debug activity") ("debug_profile_generate", "Profile work generation") ("debug_opencl", "OpenCL work generation") ("debug_profile_verify", "Profile work verification") ("debug_profile_kdf", "Profile kdf function") ("debug_verify_profile", "Profile signature verification") ("debug_profile_sign", "Profile signature generation") ("debug_xorshift_profile", "Profile xorshift algorithms") ("platform", boost::program_options::value<std::string> (), "Defines the <platform> for OpenCL commands") ("device", boost::program_options::value<std::string> (), "Defines <device> for OpenCL command") ("threads", boost::program_options::value<std::string> (), "Defines <threads> count for OpenCL command");
+
+	// clang-format off
+	description.add_options ()
+		("help", "Print out options")
+		("daemon", "Start node daemon")
+		("debug_block_count", "Display the number of block")
+		("debug_bootstrap_generate", "Generate bootstrap sequence of blocks")
+		("debug_dump_representatives", "List representatives and weights")
+		("debug_frontier_count", "Display the number of accounts")
+		("debug_mass_activity", "Generates fake debug activity")
+		("debug_profile_generate", "Profile work generation")
+		("debug_opencl", "OpenCL work generation")
+		("debug_profile_verify", "Profile work verification")
+		("debug_profile_kdf", "Profile kdf function")
+		("debug_verify_profile", "Profile signature verification")
+		("debug_profile_sign", "Profile signature generation")
+		("debug_xorshift_profile", "Profile xorshift algorithms")
+		("platform", boost::program_options::value<std::string> (), "Defines the <platform> for OpenCL commands")
+		("device", boost::program_options::value<std::string> (), "Defines <device> for OpenCL command")
+		("threads", boost::program_options::value<std::string> (), "Defines <threads> count for OpenCL command");
+	// clang-format on
+
 	boost::program_options::variables_map vm;
 	boost::program_options::store (boost::program_options::parse_command_line (argc, argv, description), vm);
 	boost::program_options::notify (vm);


### PR DESCRIPTION
I've been trying to convince clang-format to nicely format the program options, but it seems to have no knobs for tuning builder-style statements (other than ColumnLimit, which doesn't suffice.)

Options currently end up on a long line, making it hard to read and edit. Any concurrent program option edits are going to conflict.

With this patch I basically ask if using `// clang-format off` is okay for these special cases.

This may close https://github.com/clemahieu/raiblocks/issues/416