### PR TITLE
Add a new message type "bulk_pull_blocks"

### DIFF
--- a/rai/core_test/message_parser.cpp
+++ b/rai/core_test/message_parser.cpp
@@ -12,6 +12,7 @@ public:
 	confirm_req_count (0),
 	confirm_ack_count (0),
 	bulk_pull_count (0),
+	bulk_pull_blocks_count (0),
 	bulk_push_count (0),
 	frontier_req_count (0)
 	{
@@ -36,6 +37,10 @@ public:
 	{
 		++bulk_pull_count;
 	}
+	void bulk_pull_blocks (rai::bulk_pull_blocks const &)
+	{
+		++bulk_pull_blocks_count;
+	}
 	void bulk_push (rai::bulk_push const &)
 	{
 		++bulk_push_count;
@@ -49,6 +54,7 @@ public:
 	uint64_t confirm_req_count;
 	uint64_t confirm_ack_count;
 	uint64_t bulk_pull_count;
+	uint64_t bulk_pull_blocks_count;
 	uint64_t bulk_push_count;
 	uint64_t frontier_req_count;
 };

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1248,7 +1248,7 @@ void rai::bootstrap_server::receive_header_action (boost::system::error_code con
 				case rai::message_type::bulk_pull_blocks:
 				{
 					auto this_l (shared_from_this ());
-					boost::asio::async_read (*socket, boost::asio::buffer (receive_buffer.data () + 8, sizeof (rai::uint256_union) + sizeof (rai::uint256_union) + sizeof (bulk_pull_blocks_mode) + sizeof (uint32_t)), [this_l](boost::system::error_code const & ec, size_t size_a) {
+					boost::asio::async_read (*socket, boost::asio::buffer (receive_buffer.data () + rai::bootstrap_message_header_size, sizeof (rai::uint256_union) + sizeof (rai::uint256_union) + sizeof (bulk_pull_blocks_mode) + sizeof (uint32_t)), [this_l](boost::system::error_code const & ec, size_t size_a) {
 						this_l->receive_bulk_pull_blocks_action (ec, size_a);
 					});
 					break;

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1601,9 +1601,10 @@ void rai::bulk_pull_blocks_server::set_params ()
 		BOOST_LOG (connection->node->log) << boost::str (boost::format ("Bulk pull of block range starting, min (%1%) to max (%2%), max_count = %3%, mode = %4%") % request->min_hash.to_string () % request->max_hash.to_string () % request->max_count % modeName);
 	}
 
-	stream = connection->node->store.block_info_begin(stream_transaction, request->min_hash);
+	stream = connection->node->store.block_info_begin (stream_transaction, request->min_hash);
 
-	if (request->max_hash < request->min_hash) {
+	if (request->max_hash < request->min_hash)
+	{
 		if (connection->node->config.logging.bulk_pull_logging ())
 		{
 			BOOST_LOG (connection->node->log) << boost::str (boost::format ("Bulk pull of block range is invalid, min (%1%) is greater than max (%2%)") % request->min_hash.to_string () % request->max_hash.to_string ());
@@ -1698,7 +1699,7 @@ std::unique_ptr<rai::block> rai::bulk_pull_blocks_server::get_next ()
 			{
 				rai::transaction transaction (connection->node->store.environment, nullptr, false);
 				result = connection->node->store.block_get (transaction, current);
- 
+
 				++stream;
 			}
 		}

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1427,10 +1427,10 @@ void rai::bootstrap_server::run_next ()
 	requests.front ()->visit (visitor);
 }
 
-/*
- * rai::bulk_pull_server: Handle a request for the pull of all blocks associated with an account
- *                        The account is supplied as the "start" member, and the final block to
- *                        send is the "end" member
+/**
+ * Handle a request for the pull of all blocks associated with an account
+ * The account is supplied as the "start" member, and the final block to
+ * send is the "end" member
  */
 void rai::bulk_pull_server::set_current_end ()
 {
@@ -1573,12 +1573,12 @@ request (std::move (request_a))
 	set_current_end ();
 }
 
-/*
- * rai::bulk_pull_blocks_server: Bulk pull of a range of blocks, or a checksum for a range of
- *                               blocks [min_hash, max_hash] up to a max of max_count.  mode
- *                               specifies whether the list is returned or a single checksum
- *                               of all the hashes.  The checksum is computed by XORing the
- *                               hash of all the blocks that would be returned
+/**
+ * Bulk pull of a range of blocks, or a checksum for a range of
+ * blocks [min_hash, max_hash) up to a max of max_count.  mode
+ * specifies whether the list is returned or a single checksum
+ * of all the hashes.  The checksum is computed by XORing the
+ * hash of all the blocks that would be returned
  */
 void rai::bulk_pull_blocks_server::set_params ()
 {

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -246,10 +246,10 @@ public:
 	std::shared_ptr<rai::bootstrap_server> connection;
 	std::unique_ptr<rai::bulk_pull_blocks> request;
 	std::vector<uint8_t> send_buffer;
-	rai::block_hash current;
 	rai::store_iterator stream;
 	rai::transaction stream_transaction;
 	uint32_t sent_count;
+	rai::block_hash checksum;
 };
 class bulk_push_server : public std::enable_shared_from_this<rai::bulk_push_server>
 {

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -204,6 +204,7 @@ public:
 	void receive ();
 	void receive_header_action (boost::system::error_code const &, size_t);
 	void receive_bulk_pull_action (boost::system::error_code const &, size_t);
+	void receive_bulk_pull_blocks_action (boost::system::error_code const &, size_t);
 	void receive_frontier_req_action (boost::system::error_code const &, size_t);
 	void receive_bulk_push_action ();
 	void add_request (std::unique_ptr<rai::message>);
@@ -230,6 +231,24 @@ public:
 	std::unique_ptr<rai::bulk_pull> request;
 	std::vector<uint8_t> send_buffer;
 	rai::block_hash current;
+};
+class bulk_pull_blocks;
+class bulk_pull_blocks_server : public std::enable_shared_from_this<rai::bulk_pull_blocks_server>
+{
+public:
+	bulk_pull_blocks_server (std::shared_ptr<rai::bootstrap_server> const &, std::unique_ptr<rai::bulk_pull_blocks>);
+	void set_params();
+	std::unique_ptr<rai::block> get_next ();
+	void send_next ();
+	void sent_action (boost::system::error_code const &, size_t);
+	void send_finished ();
+	void no_block_sent (boost::system::error_code const &, size_t);
+	std::shared_ptr<rai::bootstrap_server> connection;
+	std::unique_ptr<rai::bulk_pull_blocks> request;
+	std::vector<uint8_t> send_buffer;
+	rai::block_hash current;
+	rai::store_iterator stream;
+	rai::transaction stream_transaction;
 };
 class bulk_push_server : public std::enable_shared_from_this<rai::bulk_push_server>
 {

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -237,7 +237,7 @@ class bulk_pull_blocks_server : public std::enable_shared_from_this<rai::bulk_pu
 {
 public:
 	bulk_pull_blocks_server (std::shared_ptr<rai::bootstrap_server> const &, std::unique_ptr<rai::bulk_pull_blocks>);
-	void set_params();
+	void set_params ();
 	std::unique_ptr<rai::block> get_next ();
 	void send_next ();
 	void sent_action (boost::system::error_code const &, size_t);

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -26,7 +26,7 @@ enum class sync_result
  * The length of every message header, parsed by rai::message::read_header ()
  * The 2 here represents the size of a std::bitset<16>, which is 2 chars long normally
  */
-const int bootstrap_message_header_size = sizeof (rai::message::magic_number) + sizeof (uint8_t) + sizeof (uint8_t) + sizeof (uint8_t) + sizeof (rai::message_type) + 2;
+static const int bootstrap_message_header_size = sizeof (rai::message::magic_number) + sizeof (uint8_t) + sizeof (uint8_t) + sizeof (uint8_t) + sizeof (rai::message_type) + 2;
 
 class block_synchronization
 {

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -249,6 +249,7 @@ public:
 	rai::block_hash current;
 	rai::store_iterator stream;
 	rai::transaction stream_transaction;
+	uint32_t sent_count;
 };
 class bulk_push_server : public std::enable_shared_from_this<rai::bulk_push_server>
 {

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -21,6 +21,12 @@ enum class sync_result
 	error,
 	fork
 };
+
+/**
+ * The length of every message header, parsed by rai::message::read_header ()
+ */
+const int bootstrap_message_header_size = sizeof (rai::message::magic_number) + sizeof (uint8_t) + sizeof (uint8_t) + sizeof (uint8_t) + sizeof (rai::message_type) + sizeof (std::bitset<16>);
+
 class block_synchronization
 {
 public:

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -24,8 +24,9 @@ enum class sync_result
 
 /**
  * The length of every message header, parsed by rai::message::read_header ()
+ * The 2 here represents the size of a std::bitset<16>, which is 2 chars long normally
  */
-const int bootstrap_message_header_size = sizeof (rai::message::magic_number) + sizeof (uint8_t) + sizeof (uint8_t) + sizeof (uint8_t) + sizeof (rai::message_type) + sizeof (std::bitset<16>);
+const int bootstrap_message_header_size = sizeof (rai::message::magic_number) + sizeof (uint8_t) + sizeof (uint8_t) + sizeof (uint8_t) + sizeof (rai::message_type) + 2;
 
 class block_synchronization
 {

--- a/rai/node/common.cpp
+++ b/rai/node/common.cpp
@@ -496,6 +496,52 @@ void rai::bulk_pull::serialize (rai::stream & stream_a)
 	write (stream_a, end);
 }
 
+rai::bulk_pull_blocks::bulk_pull_blocks () :
+message (rai::message_type::bulk_pull_blocks)
+{
+}
+
+void rai::bulk_pull_blocks::visit (rai::message_visitor & visitor_a) const
+{
+	visitor_a.bulk_pull_blocks (*this);
+}
+
+bool rai::bulk_pull_blocks::deserialize (rai::stream & stream_a)
+{
+	auto result (read_header (stream_a, version_max, version_using, version_min, type, extensions));
+	assert (!result);
+	assert (rai::message_type::bulk_pull_blocks == type);
+	if (!result)
+	{
+		assert (type == rai::message_type::bulk_pull_blocks);
+		result = read (stream_a, min_hash);
+		if (!result)
+		{
+			result = read (stream_a, max_hash);
+		}
+
+		if (!result)
+		{
+			result = read (stream_a, mode);
+		}
+
+		if (!result)
+		{
+			result = read (stream_a, max_count);
+		}
+	}
+	return result;
+}
+
+void rai::bulk_pull_blocks::serialize (rai::stream & stream_a)
+{
+	write_header (stream_a);
+	write (stream_a, min_hash);
+	write (stream_a, max_hash);
+	write (stream_a, mode);
+	write (stream_a, max_count);
+}
+
 rai::bulk_push::bulk_push () :
 message (rai::message_type::bulk_push)
 {

--- a/rai/node/common.hpp
+++ b/rai/node/common.hpp
@@ -92,7 +92,13 @@ enum class message_type : uint8_t
 	confirm_ack,
 	bulk_pull,
 	bulk_push,
-	frontier_req
+	frontier_req,
+	bulk_pull_blocks
+};
+enum class bulk_pull_blocks_mode : uint8_t
+{
+	list_blocks,
+	checksum_blocks
 };
 class message_visitor;
 class message
@@ -201,6 +207,18 @@ public:
 	rai::uint256_union start;
 	rai::block_hash end;
 };
+class bulk_pull_blocks : public message
+{
+public:
+	bulk_pull_blocks ();
+	bool deserialize (rai::stream &) override;
+	void serialize (rai::stream &) override;
+	void visit (rai::message_visitor &) const override;
+	rai::block_hash min_hash;
+	rai::block_hash max_hash;
+	bulk_pull_blocks_mode mode;
+	uint32_t max_count;
+};
 class bulk_push : public message
 {
 public:
@@ -217,6 +235,7 @@ public:
 	virtual void confirm_req (rai::confirm_req const &) = 0;
 	virtual void confirm_ack (rai::confirm_ack const &) = 0;
 	virtual void bulk_pull (rai::bulk_pull const &) = 0;
+	virtual void bulk_pull_blocks (rai::bulk_pull_blocks const &) = 0;
 	virtual void bulk_push (rai::bulk_push const &) = 0;
 	virtual void frontier_req (rai::frontier_req const &) = 0;
 };

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -402,6 +402,10 @@ public:
 	{
 		assert (false);
 	}
+	void bulk_pull_blocks (rai::bulk_pull_blocks const &) override
+	{
+		assert (false);
+	}
 	void bulk_push (rai::bulk_push const &) override
 	{
 		assert (false);


### PR DESCRIPTION
This patchset adds a new message type "bulk_pull_blocks" (0x09) which allows one to request from a
node a range of blocks (min_hash to max_hash).  Alternatively, the checksum for a range of blocks can
be requested to  determine if it is likely that there are new blocks in that range that need to be pulled.

Further, a limited number of blocks can be requested by specifying a non-zero "max_count" argument.