### PR TITLE
Re-enable payment_wait test

### DIFF
--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -1171,7 +1171,7 @@ TEST (rpc, payment_begin_locked)
 	ASSERT_FALSE (response1.json.get<std::string> ("error").empty ());
 }
 
-TEST (rpc, DISABLED_payment_wait)
+TEST (rpc, payment_wait)
 {
 	rai::system system (24000, 1);
 	rai::node_init init1;


### PR DESCRIPTION
Not sure why it was disabled, but it passes consistently on my machine. It takes about 1 second, which I don't think is too long.