### PR TITLE
Improve bootstrap performance.

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -744,7 +744,7 @@ password_fanout (1024),
 io_threads (std::max<unsigned> (4, std::thread::hardware_concurrency ())),
 work_threads (std::max<unsigned> (4, std::thread::hardware_concurrency ())),
 enable_voting (true),
-bootstrap_connections (4),
+bootstrap_connections (16),
 callback_port (0),
 lmdb_max_dbs (128)
 {


### PR DESCRIPTION
This patch reduces initial bootstrap times by searching for higher-performing peers, and improves the overall behavior when the number of bootstrap peers is high.

I recommend setting "bootstrap_connections" to 32, 64 or 128 in the config to test.
