### PR TITLE
Fix ci/bootstrap_boost.sh to rm what's intended

### DIFF
--- a/ci/bootstrap_boost.sh
+++ b/ci/bootstrap_boost.sh
@@ -9,7 +9,7 @@ tar xf ${BOOST_BASENAME}.tar.gz
 cd ${BOOST_BASENAME}
 ./bootstrap.sh
 ./b2 --prefix=${BOOST_ROOT} link=static install
+cd ..
 rm -rf ${BOOST_BASENAME}
 rm -f ${BOOST_BASENAME}.tar.gz
-cd ..
-mkdir app
+mkdir -p app


### PR DESCRIPTION
Also add -p for mkdir for when first run of the script fails.