### PR TITLE
Use steady_clock and clean up epoch-time use

### DIFF
--- a/rai/core_test/block_store.cpp
+++ b/rai/core_test/block_store.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <rai/node/common.hpp>
 #include <rai/node/node.hpp>
 #include <rai/versioning.hpp>
 
@@ -9,7 +10,7 @@ TEST (block_store, construction)
 	bool init (false);
 	rai::block_store store (init, rai::unique_path ());
 	ASSERT_TRUE (!init);
-	auto now (store.now ());
+	auto now (rai::seconds_since_epoch ());
 	ASSERT_GT (now, 1408074640);
 }
 
@@ -154,7 +155,7 @@ TEST (block_store, genesis)
 	ASSERT_NE (nullptr, block1);
 	auto receive1 (dynamic_cast<rai::open_block *> (block1.get ()));
 	ASSERT_NE (nullptr, receive1);
-	ASSERT_LE (info.modified, store.now ());
+	ASSERT_LE (info.modified, rai::seconds_since_epoch ());
 	auto test_pub_text (rai::test_genesis_key.pub.to_string ());
 	auto test_pub_account (rai::test_genesis_key.pub.to_account ());
 	auto test_prv_text (rai::test_genesis_key.prv.data.to_string ());

--- a/rai/core_test/gap_cache.cpp
+++ b/rai/core_test/gap_cache.cpp
@@ -20,7 +20,7 @@ TEST (gap_cache, add_existing)
 	auto existing1 (cache.blocks.get<1> ().find (block1->hash ()));
 	ASSERT_NE (cache.blocks.get<1> ().end (), existing1);
 	auto arrival (existing1->arrival);
-	while (arrival == std::chrono::system_clock::now ())
+	while (arrival == std::chrono::steady_clock::now ())
 		;
 	cache.add (transaction, block1);
 	ASSERT_EQ (1, cache.blocks.size ());
@@ -39,7 +39,7 @@ TEST (gap_cache, comparison)
 	auto existing1 (cache.blocks.get<1> ().find (block1->hash ()));
 	ASSERT_NE (cache.blocks.get<1> ().end (), existing1);
 	auto arrival (existing1->arrival);
-	while (std::chrono::system_clock::now () == arrival)
+	while (std::chrono::steady_clock::now () == arrival)
 		;
 	auto block3 (std::make_shared<rai::send_block> (0, 42, 1, rai::keypair ().prv, 3, 4));
 	cache.add (transaction, block3);

--- a/rai/core_test/ledger.cpp
+++ b/rai/core_test/ledger.cpp
@@ -42,8 +42,8 @@ TEST (ledger, genesis_balance)
 	rai::account_info info;
 	ASSERT_FALSE (store.account_get (transaction, rai::genesis_account, info));
 	// Frontier time should have been updated when genesis balance was added
-	ASSERT_GE (store.now (), info.modified);
-	ASSERT_LT (store.now () - info.modified, 10);
+	ASSERT_GE (rai::seconds_since_epoch (), info.modified);
+	ASSERT_LT (rai::seconds_since_epoch () - info.modified, 10);
 }
 
 // Make sure the checksum is the same when ledger reloaded

--- a/rai/core_test/network.cpp
+++ b/rai/core_test/network.cpp
@@ -887,8 +887,8 @@ TEST (node, port_mapping)
 	auto node0 (system.nodes[0]);
 	node0->port_mapping.refresh_devices ();
 	node0->port_mapping.start ();
-	auto end (std::chrono::system_clock::now () + std::chrono::seconds (500));
-	//while (std::chrono::system_clock::now () < end)
+	auto end (std::chrono::steady_clock::now () + std::chrono::seconds (500));
+	//while (std::chrono::steady_clock::now () < end)
 	{
 		system.poll ();
 	}

--- a/rai/core_test/peer_container.cpp
+++ b/rai/core_test/peer_container.cpp
@@ -4,7 +4,7 @@
 TEST (peer_container, empty_peers)
 {
 	rai::peer_container peers (rai::endpoint{});
-	auto list (peers.purge_list (std::chrono::system_clock::now ()));
+	auto list (peers.purge_list (std::chrono::steady_clock::now ()));
 	ASSERT_EQ (0, list.size ());
 }
 
@@ -20,7 +20,7 @@ TEST (peer_container, no_recontact)
 	ASSERT_FALSE (peers.insert (endpoint1, 0));
 	ASSERT_EQ (1, peers.size ());
 	ASSERT_TRUE (peers.insert (endpoint1, 0));
-	auto remaining (peers.purge_list (std::chrono::system_clock::now () + std::chrono::seconds (5)));
+	auto remaining (peers.purge_list (std::chrono::steady_clock::now () + std::chrono::seconds (5)));
 	ASSERT_TRUE (remaining.empty ());
 	ASSERT_EQ (1, observed_peer);
 	ASSERT_TRUE (observed_disconnect);
@@ -58,7 +58,7 @@ TEST (peer_container, reserved_peers_no_contact)
 TEST (peer_container, split)
 {
 	rai::peer_container peers (rai::endpoint{});
-	auto now (std::chrono::system_clock::now ());
+	auto now (std::chrono::steady_clock::now ());
 	rai::endpoint endpoint1 (boost::asio::ip::address_v6::any (), 100);
 	rai::endpoint endpoint2 (boost::asio::ip::address_v6::any (), 101);
 	peers.peers.insert (rai::peer_information (endpoint1, now - std::chrono::seconds (1), now));
@@ -153,9 +153,9 @@ TEST (peer_container, reachout)
 	// Reaching out to them once should signal we shouldn't reach out again.
 	ASSERT_TRUE (peers.reachout (endpoint1));
 	// Make sure we don't purge new items
-	peers.purge_list (std::chrono::system_clock::now () - std::chrono::seconds (10));
+	peers.purge_list (std::chrono::steady_clock::now () - std::chrono::seconds (10));
 	ASSERT_TRUE (peers.reachout (endpoint1));
 	// Make sure we purge old items
-	peers.purge_list (std::chrono::system_clock::now () + std::chrono::seconds (10));
+	peers.purge_list (std::chrono::steady_clock::now () + std::chrono::seconds (10));
 	ASSERT_FALSE (peers.reachout (endpoint1));
 }

--- a/rai/core_test/processor_service.cpp
+++ b/rai/core_test/processor_service.cpp
@@ -52,7 +52,7 @@ TEST (alarm, one)
 	std::atomic<bool> done (false);
 	std::mutex mutex;
 	std::condition_variable condition;
-	alarm.add (std::chrono::system_clock::now (), [&]() {
+	alarm.add (std::chrono::steady_clock::now (), [&]() {
 		std::lock_guard<std::mutex> lock (mutex);
 		done = true;
 		condition.notify_one ();
@@ -74,7 +74,7 @@ TEST (alarm, many)
 	std::condition_variable condition;
 	for (auto i (0); i < 50; ++i)
 	{
-		alarm.add (std::chrono::system_clock::now (), [&]() {
+		alarm.add (std::chrono::steady_clock::now (), [&]() {
 			std::lock_guard<std::mutex> lock (mutex);
 			count += 1;
 			condition.notify_one ();
@@ -103,12 +103,12 @@ TEST (alarm, top_execution)
 	int value2 (0);
 	std::mutex mutex;
 	std::promise<bool> promise;
-	alarm.add (std::chrono::system_clock::now (), [&]() {
+	alarm.add (std::chrono::steady_clock::now (), [&]() {
 		std::lock_guard<std::mutex> lock (mutex);
 		value1 = 1;
 		value2 = 1;
 	});
-	alarm.add (std::chrono::system_clock::now () + std::chrono::milliseconds (1), [&]() {
+	alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (1), [&]() {
 		std::lock_guard<std::mutex> lock (mutex);
 		value2 = 2;
 		promise.set_value (false);

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -122,7 +122,7 @@ public:
 	rai::account landing;
 	rai::account faucet;
 	std::chrono::steady_clock::time_point start_time;
-	std::chrono::system_clock::time_point next_report;
+	std::chrono::steady_clock::time_point next_report;
 	std::promise<bool> promise;
 };
 class bulk_pull_client : public std::enable_shared_from_this<rai::bulk_pull_client>

--- a/rai/node/common.hpp
+++ b/rai/node/common.hpp
@@ -240,4 +240,12 @@ public:
 	virtual void frontier_req (rai::frontier_req const &) = 0;
 	virtual ~message_visitor ();
 };
+
+/**
+ * Returns seconds passed since unix epoch (posix time)
+ */
+inline uint64_t seconds_since_epoch ()
+{
+	return std::chrono::duration_cast<std::chrono::seconds> (std::chrono::system_clock::now ().time_since_epoch ()).count ();
+}
 }

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -225,9 +225,9 @@ void rai::network::republish_block (MDB_txn * transaction, std::shared_ptr<rai::
 // 1) Only if they are a non-replay vote of a block that's actively settling. Settling blocks are limited by block PoW
 // 2) Only if a vote for this block hasn't been received in the previous X second.  This prevents rapid publishing of votes with increasing sequence numbers.
 // 3) The rep has a weight > Y to prevent creating a lot of small-weight accounts to send out votes
-void rai::network::republish_vote (std::chrono::system_clock::time_point const & last_vote, std::shared_ptr<rai::vote> vote_a)
+void rai::network::republish_vote (std::chrono::steady_clock::time_point const & last_vote, std::shared_ptr<rai::vote> vote_a)
 {
-	if (last_vote < std::chrono::system_clock::now () - std::chrono::seconds (1))
+	if (last_vote < std::chrono::steady_clock::now () - std::chrono::seconds (1))
 	{
 		if (node.weight (vote_a->account) > rai::Mxrb_ratio * 256)
 		{
@@ -297,7 +297,7 @@ void rep_query (rai::node & node_a, T const & peers_a)
 		node_a.network.send_confirm_req (*i, block);
 	}
 	std::weak_ptr<rai::node> node_w (node_a.shared ());
-	node_a.alarm.add (std::chrono::system_clock::now () + std::chrono::seconds (5), [node_w, hash]() {
+	node_a.alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (5), [node_w, hash]() {
 		if (auto node_l = node_w.lock ())
 		{
 			node_l->rep_crawler.remove (hash);
@@ -456,7 +456,7 @@ void rai::network::receive_action (boost::system::error_code const & error, size
 		}
 		if (on)
 		{
-			node.alarm.add (std::chrono::system_clock::now () + std::chrono::seconds (5), [this]() { receive (); });
+			node.alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (5), [this]() { receive (); });
 		}
 	}
 }
@@ -486,7 +486,7 @@ thread ([this]() { run (); })
 
 rai::alarm::~alarm ()
 {
-	add (std::chrono::system_clock::now (), nullptr);
+	add (std::chrono::steady_clock::now (), nullptr);
 	thread.join ();
 }
 
@@ -501,7 +501,7 @@ void rai::alarm::run ()
 			auto & operation (operations.top ());
 			if (operation.function)
 			{
-				if (operation.wakeup <= std::chrono::system_clock::now ())
+				if (operation.wakeup <= std::chrono::steady_clock::now ())
 				{
 					service.post (operation.function);
 					operations.pop ();
@@ -524,7 +524,7 @@ void rai::alarm::run ()
 	}
 }
 
-void rai::alarm::add (std::chrono::system_clock::time_point const & wakeup_a, std::function<void()> const & operation)
+void rai::alarm::add (std::chrono::steady_clock::time_point const & wakeup_a, std::function<void()> const & operation)
 {
 	std::lock_guard<std::mutex> lock (mutex);
 	operations.push (rai::operation ({ wakeup_a, operation }));
@@ -1146,8 +1146,8 @@ void rai::block_processor::process_receive_many (std::deque<rai::block_processor
 		std::deque<std::pair<std::shared_ptr<rai::block>, rai::process_return>> progress;
 		{
 			rai::transaction transaction (node.store.environment, nullptr, true);
-			auto cutoff (std::chrono::system_clock::now () + rai::transaction_timeout);
-			while (!blocks_processing.empty () && std::chrono::system_clock::now () < cutoff)
+			auto cutoff (std::chrono::steady_clock::now () + rai::transaction_timeout);
+			while (!blocks_processing.empty () && std::chrono::steady_clock::now () < cutoff)
 			{
 				auto item (blocks_processing.front ());
 				blocks_processing.pop_front ();
@@ -1538,12 +1538,12 @@ void rai::gap_cache::add (MDB_txn * transaction_a, std::shared_ptr<rai::block> b
 	if (existing != blocks.get<1> ().end ())
 	{
 		blocks.get<1> ().modify (existing, [](rai::gap_information & info) {
-			info.arrival = std::chrono::system_clock::now ();
+			info.arrival = std::chrono::steady_clock::now ();
 		});
 	}
 	else
 	{
-		blocks.insert ({ std::chrono::system_clock::now (), hash, std::unique_ptr<rai::votes> (new rai::votes (block_a)) });
+		blocks.insert ({ std::chrono::steady_clock::now (), hash, std::unique_ptr<rai::votes> (new rai::votes (block_a)) });
 		if (blocks.size () > max)
 		{
 			blocks.get<0> ().erase (blocks.get<0> ().begin ());
@@ -1564,7 +1564,7 @@ void rai::gap_cache::vote (std::shared_ptr<rai::vote> vote_a)
 		if (winner.first > bootstrap_threshold (transaction))
 		{
 			auto node_l (node.shared ());
-			auto now (std::chrono::system_clock::now ());
+			auto now (std::chrono::steady_clock::now ());
 			node.alarm.add (rai::rai_network == rai::rai_networks::rai_test_network ? now + std::chrono::milliseconds (5) : now + std::chrono::seconds (5), [node_l, hash]() {
 				rai::transaction transaction (node_l->store.environment, nullptr, false);
 				if (!node_l->store.block_exists (transaction, hash))
@@ -1588,7 +1588,7 @@ rai::uint128_t rai::gap_cache::bootstrap_threshold (MDB_txn * transaction_a)
 
 void rai::gap_cache::purge_old ()
 {
-	auto cutoff (std::chrono::system_clock::now () - std::chrono::seconds (10));
+	auto cutoff (std::chrono::steady_clock::now () - std::chrono::seconds (10));
 	std::lock_guard<std::mutex> lock (mutex);
 	auto done (false);
 	while (!done && !blocks.empty ())
@@ -1685,7 +1685,7 @@ rai::endpoint rai::peer_container::bootstrap_peer ()
 		{
 			result = i->endpoint;
 			peers.get<4> ().modify (i, [](rai::peer_information & peer_a) {
-				peer_a.last_bootstrap_attempt = std::chrono::system_clock::now ();
+				peer_a.last_bootstrap_attempt = std::chrono::steady_clock::now ();
 			});
 			i = n;
 		}
@@ -1863,13 +1863,13 @@ rai::account rai::node::representative (rai::account const & account_a)
 void rai::node::ongoing_keepalive ()
 {
 	keepalive_preconfigured (config.preconfigured_peers);
-	auto peers_l (peers.purge_list (std::chrono::system_clock::now () - cutoff));
-	for (auto i (peers_l.begin ()), j (peers_l.end ()); i != j && std::chrono::system_clock::now () - i->last_attempt > period; ++i)
+	auto peers_l (peers.purge_list (std::chrono::steady_clock::now () - cutoff));
+	for (auto i (peers_l.begin ()), j (peers_l.end ()); i != j && std::chrono::steady_clock::now () - i->last_attempt > period; ++i)
 	{
 		network.send_keepalive (i->endpoint);
 	}
 	std::weak_ptr<rai::node> node_w (shared_from_this ());
-	alarm.add (std::chrono::system_clock::now () + period, [node_w]() {
+	alarm.add (std::chrono::steady_clock::now () + period, [node_w]() {
 		if (auto node_l = node_w.lock ())
 		{
 			node_l->ongoing_keepalive ();
@@ -1879,7 +1879,7 @@ void rai::node::ongoing_keepalive ()
 
 void rai::node::ongoing_rep_crawl ()
 {
-	auto now (std::chrono::system_clock::now ());
+	auto now (std::chrono::steady_clock::now ());
 	auto peers_l (peers.rep_crawl ());
 	rep_query (*this, peers_l);
 	if (network.on)
@@ -1908,7 +1908,7 @@ void rai::node::ongoing_bootstrap ()
 	}
 	bootstrap_initiator.bootstrap ();
 	std::weak_ptr<rai::node> node_w (shared_from_this ());
-	alarm.add (std::chrono::system_clock::now () + std::chrono::seconds (next_wakeup), [node_w]() {
+	alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (next_wakeup), [node_w]() {
 		if (auto node_l = node_w.lock ())
 		{
 			node_l->ongoing_bootstrap ();
@@ -1923,7 +1923,7 @@ void rai::node::ongoing_store_flush ()
 		store.flush (transaction);
 	}
 	std::weak_ptr<rai::node> node_w (shared_from_this ());
-	alarm.add (std::chrono::system_clock::now () + std::chrono::seconds (5), [node_w]() {
+	alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (5), [node_w]() {
 		if (auto node_l = node_w.lock ())
 		{
 			node_l->ongoing_store_flush ();
@@ -1941,7 +1941,7 @@ void rai::node::backup_wallet ()
 		i->second->store.write_backup (transaction, backup_path / (i->first.to_string () + ".json"));
 	}
 	auto this_l (shared ());
-	alarm.add (std::chrono::system_clock::now () + backup_interval, [this_l]() {
+	alarm.add (std::chrono::steady_clock::now () + backup_interval, [this_l]() {
 		this_l->backup_wallet ();
 	});
 }
@@ -2279,14 +2279,14 @@ rai::endpoint rai::network::endpoint ()
 void rai::block_arrival::add (rai::block_hash const & hash_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
-	auto now (std::chrono::system_clock::now ());
+	auto now (std::chrono::steady_clock::now ());
 	arrival.insert (rai::block_arrival_info{ now, hash_a });
 }
 
 bool rai::block_arrival::recent (rai::block_hash const & hash_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
-	auto now (std::chrono::system_clock::now ());
+	auto now (std::chrono::steady_clock::now ());
 	while (!arrival.empty () && arrival.begin ()->arrival + std::chrono::seconds (60) < now)
 	{
 		arrival.erase (arrival.begin ());
@@ -2352,7 +2352,7 @@ std::vector<rai::peer_information> rai::peer_container::representatives (size_t 
 	return result;
 }
 
-std::vector<rai::peer_information> rai::peer_container::purge_list (std::chrono::system_clock::time_point const & cutoff)
+std::vector<rai::peer_information> rai::peer_container::purge_list (std::chrono::steady_clock::time_point const & cutoff)
 {
 	std::vector<rai::peer_information> result;
 	{
@@ -2363,7 +2363,7 @@ std::vector<rai::peer_information> rai::peer_container::purge_list (std::chrono:
 		peers.get<1> ().erase (peers.get<1> ().begin (), pivot);
 		for (auto i (peers.begin ()), n (peers.end ()); i != n; ++i)
 		{
-			peers.modify (i, [](rai::peer_information & info) { info.last_attempt = std::chrono::system_clock::now (); });
+			peers.modify (i, [](rai::peer_information & info) { info.last_attempt = std::chrono::steady_clock::now (); });
 		}
 
 		// Remove keepalive attempt tracking for attempts older than cutoff
@@ -2433,7 +2433,7 @@ bool rai::peer_container::rep_response (rai::endpoint const & endpoint_a, rai::a
 	if (existing != peers.end ())
 	{
 		peers.modify (existing, [weight_a, &updated](rai::peer_information & info) {
-			info.last_rep_response = std::chrono::system_clock::now ();
+			info.last_rep_response = std::chrono::steady_clock::now ();
 			if (info.rep_weight < weight_a)
 			{
 				updated = true;
@@ -2451,7 +2451,7 @@ void rai::peer_container::rep_request (rai::endpoint const & endpoint_a)
 	if (existing != peers.end ())
 	{
 		peers.modify (existing, [](rai::peer_information & info) {
-			info.last_rep_request = std::chrono::system_clock::now ();
+			info.last_rep_request = std::chrono::steady_clock::now ();
 		});
 	}
 }
@@ -2466,7 +2466,7 @@ bool rai::peer_container::reachout (rai::endpoint const & endpoint_a)
 	std::lock_guard<std::mutex> lock (mutex);
 	auto existing (attempts.find (endpoint_a));
 	result |= existing != attempts.end ();
-	attempts.insert ({ endpoint_a, std::chrono::system_clock::now () });
+	attempts.insert ({ endpoint_a, std::chrono::steady_clock::now () });
 	return result;
 }
 
@@ -2481,7 +2481,7 @@ bool rai::peer_container::insert (rai::endpoint const & endpoint_a, unsigned ver
 		if (existing != peers.end ())
 		{
 			peers.modify (existing, [](rai::peer_information & info) {
-				info.last_contact = std::chrono::system_clock::now ();
+				info.last_contact = std::chrono::steady_clock::now ();
 			});
 			result = true;
 		}
@@ -2580,23 +2580,23 @@ bool rai::reserved_address (rai::endpoint const & endpoint_a)
 
 rai::peer_information::peer_information (rai::endpoint const & endpoint_a, unsigned network_version_a) :
 endpoint (endpoint_a),
-last_contact (std::chrono::system_clock::now ()),
+last_contact (std::chrono::steady_clock::now ()),
 last_attempt (last_contact),
-last_bootstrap_attempt (std::chrono::system_clock::time_point ()),
-last_rep_request (std::chrono::system_clock::time_point ()),
-last_rep_response (std::chrono::system_clock::time_point ()),
+last_bootstrap_attempt (std::chrono::steady_clock::time_point ()),
+last_rep_request (std::chrono::steady_clock::time_point ()),
+last_rep_response (std::chrono::steady_clock::time_point ()),
 rep_weight (0),
 network_version (network_version_a)
 {
 }
 
-rai::peer_information::peer_information (rai::endpoint const & endpoint_a, std::chrono::system_clock::time_point const & last_contact_a, std::chrono::system_clock::time_point const & last_attempt_a) :
+rai::peer_information::peer_information (rai::endpoint const & endpoint_a, std::chrono::steady_clock::time_point const & last_contact_a, std::chrono::steady_clock::time_point const & last_attempt_a) :
 endpoint (endpoint_a),
 last_contact (last_contact_a),
 last_attempt (last_attempt_a),
-last_bootstrap_attempt (std::chrono::system_clock::time_point ()),
-last_rep_request (std::chrono::system_clock::time_point ()),
-last_rep_response (std::chrono::system_clock::time_point ()),
+last_bootstrap_attempt (std::chrono::steady_clock::time_point ()),
+last_rep_request (std::chrono::steady_clock::time_point ()),
+last_rep_response (std::chrono::steady_clock::time_point ()),
 rep_weight (0)
 {
 }
@@ -2619,15 +2619,6 @@ void rai::peer_container::contacted (rai::endpoint const & endpoint_a, unsigned 
 	insert (endpoint_l, version_a);
 }
 
-std::ostream & operator<< (std::ostream & stream_a, std::chrono::system_clock::time_point const & time_a)
-{
-	time_t last_contact (std::chrono::system_clock::to_time_t (time_a));
-	std::string string (ctime (&last_contact));
-	string.pop_back ();
-	stream_a << string;
-	return stream_a;
-}
-
 void rai::network::send_buffer (uint8_t const * data_a, size_t size_a, rai::endpoint const & endpoint_a, std::function<void(boost::system::error_code const &, size_t)> callback_a)
 {
 	std::unique_lock<std::mutex> lock (socket_mutex);
@@ -2642,14 +2633,6 @@ void rai::network::send_buffer (uint8_t const * data_a, size_t size_a, rai::endp
 			BOOST_LOG (this->node.log) << "Packet send complete";
 		}
 	});
-}
-
-uint64_t rai::block_store::now ()
-{
-	boost::posix_time::ptime epoch (boost::gregorian::date (1970, 1, 1));
-	auto now (boost::posix_time::second_clock::universal_time ());
-	auto diff (now - epoch);
-	return diff.total_seconds ();
 }
 
 bool rai::peer_container::known_peer (rai::endpoint const & endpoint_a)
@@ -2668,7 +2651,7 @@ rai::election::election (MDB_txn * transaction_a, rai::node & node_a, std::share
 confirmation_action (confirmation_action_a),
 votes (block_a),
 node (node_a),
-last_vote (std::chrono::system_clock::now ()),
+last_vote (std::chrono::steady_clock::now ()),
 last_winner (block_a)
 {
 	assert (node_a.store.block_exists (transaction_a, block_a->hash ()));
@@ -2772,7 +2755,7 @@ void rai::election::confirm_cutoff (MDB_txn * transaction_a)
 void rai::election::vote (std::shared_ptr<rai::vote> vote_a)
 {
 	node.network.republish_vote (last_vote, vote_a);
-	last_vote = std::chrono::system_clock::now ();
+	last_vote = std::chrono::steady_clock::now ();
 	rai::transaction transaction (node.store.environment, nullptr, true);
 	assert (node.store.vote_validate (transaction, vote_a).code != rai::vote_code::invalid);
 	votes.vote (vote_a);
@@ -2830,7 +2813,7 @@ void rai::active_transactions::announce_votes ()
 		assert (roots.find (*i) != roots.end ());
 		roots.erase (*i);
 	}
-	auto now (std::chrono::system_clock::now ());
+	auto now (std::chrono::steady_clock::now ());
 	auto node_l (node.shared ());
 	node.alarm.add (now + std::chrono::milliseconds (announce_interval_ms), [node_l]() { node_l->active.announce_votes (); });
 }
@@ -3713,7 +3696,7 @@ void rai::port_mapping::check_mapping_loop ()
 	if (on)
 	{
 		auto node_l (node.shared ());
-		node.alarm.add (std::chrono::system_clock::now () + std::chrono::seconds (wait_duration), [node_l]() {
+		node.alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (wait_duration), [node_l]() {
 			node_l->port_mapping.check_mapping_loop ();
 		});
 	}

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -23,8 +23,6 @@
 
 #include <miniupnpc.h>
 
-std::ostream & operator<< (std::ostream &, std::chrono::system_clock::time_point const &);
-
 namespace boost
 {
 namespace program_options
@@ -59,7 +57,7 @@ public:
 	rai::uint128_t minimum_threshold (MDB_txn *, rai::ledger &);
 	rai::votes votes;
 	rai::node & node;
-	std::chrono::system_clock::time_point last_vote;
+	std::chrono::steady_clock::time_point last_vote;
 	std::shared_ptr<rai::block> last_winner;
 	std::atomic_flag confirmed;
 };
@@ -102,7 +100,7 @@ class operation
 {
 public:
 	bool operator> (rai::operation const &) const;
-	std::chrono::system_clock::time_point wakeup;
+	std::chrono::steady_clock::time_point wakeup;
 	std::function<void()> function;
 };
 class alarm
@@ -110,7 +108,7 @@ class alarm
 public:
 	alarm (boost::asio::io_service &);
 	~alarm ();
-	void add (std::chrono::system_clock::time_point const &, std::function<void()> const &);
+	void add (std::chrono::steady_clock::time_point const &, std::function<void()> const &);
 	void run ();
 	boost::asio::io_service & service;
 	std::mutex mutex;
@@ -121,7 +119,7 @@ public:
 class gap_information
 {
 public:
-	std::chrono::system_clock::time_point arrival;
+	std::chrono::steady_clock::time_point arrival;
 	rai::block_hash hash;
 	std::unique_ptr<rai::votes> votes;
 };
@@ -136,7 +134,7 @@ public:
 	boost::multi_index_container<
 	rai::gap_information,
 	boost::multi_index::indexed_by<
-	boost::multi_index::ordered_non_unique<boost::multi_index::member<gap_information, std::chrono::system_clock::time_point, &gap_information::arrival>>,
+	boost::multi_index::ordered_non_unique<boost::multi_index::member<gap_information, std::chrono::steady_clock::time_point, &gap_information::arrival>>,
 	boost::multi_index::hashed_unique<boost::multi_index::member<gap_information, rai::block_hash, &gap_information::hash>>>>
 	blocks;
 	size_t const max = 256;
@@ -148,13 +146,13 @@ class peer_information
 {
 public:
 	peer_information (rai::endpoint const &, unsigned);
-	peer_information (rai::endpoint const &, std::chrono::system_clock::time_point const &, std::chrono::system_clock::time_point const &);
+	peer_information (rai::endpoint const &, std::chrono::steady_clock::time_point const &, std::chrono::steady_clock::time_point const &);
 	rai::endpoint endpoint;
-	std::chrono::system_clock::time_point last_contact;
-	std::chrono::system_clock::time_point last_attempt;
-	std::chrono::system_clock::time_point last_bootstrap_attempt;
-	std::chrono::system_clock::time_point last_rep_request;
-	std::chrono::system_clock::time_point last_rep_response;
+	std::chrono::steady_clock::time_point last_contact;
+	std::chrono::steady_clock::time_point last_attempt;
+	std::chrono::steady_clock::time_point last_bootstrap_attempt;
+	std::chrono::steady_clock::time_point last_rep_request;
+	std::chrono::steady_clock::time_point last_rep_response;
 	rai::amount rep_weight;
 	unsigned network_version;
 };
@@ -162,7 +160,7 @@ class peer_attempt
 {
 public:
 	rai::endpoint endpoint;
-	std::chrono::system_clock::time_point last_attempt;
+	std::chrono::steady_clock::time_point last_attempt;
 };
 class peer_container
 {
@@ -188,7 +186,7 @@ public:
 	// Get the next peer for attempting bootstrap
 	rai::endpoint bootstrap_peer ();
 	// Purge any peer where last_contact < time_point and return what was left
-	std::vector<rai::peer_information> purge_list (std::chrono::system_clock::time_point const &);
+	std::vector<rai::peer_information> purge_list (std::chrono::steady_clock::time_point const &);
 	std::vector<rai::endpoint> rep_crawl ();
 	bool rep_response (rai::endpoint const &, rai::amount const &);
 	void rep_request (rai::endpoint const &);
@@ -203,18 +201,18 @@ public:
 	peer_information,
 	boost::multi_index::indexed_by<
 	boost::multi_index::hashed_unique<boost::multi_index::member<peer_information, rai::endpoint, &peer_information::endpoint>>,
-	boost::multi_index::ordered_non_unique<boost::multi_index::member<peer_information, std::chrono::system_clock::time_point, &peer_information::last_contact>>,
-	boost::multi_index::ordered_non_unique<boost::multi_index::member<peer_information, std::chrono::system_clock::time_point, &peer_information::last_attempt>, std::greater<std::chrono::system_clock::time_point>>,
+	boost::multi_index::ordered_non_unique<boost::multi_index::member<peer_information, std::chrono::steady_clock::time_point, &peer_information::last_contact>>,
+	boost::multi_index::ordered_non_unique<boost::multi_index::member<peer_information, std::chrono::steady_clock::time_point, &peer_information::last_attempt>, std::greater<std::chrono::steady_clock::time_point>>,
 	boost::multi_index::random_access<>,
-	boost::multi_index::ordered_non_unique<boost::multi_index::member<peer_information, std::chrono::system_clock::time_point, &peer_information::last_bootstrap_attempt>>,
-	boost::multi_index::ordered_non_unique<boost::multi_index::member<peer_information, std::chrono::system_clock::time_point, &peer_information::last_rep_request>>,
+	boost::multi_index::ordered_non_unique<boost::multi_index::member<peer_information, std::chrono::steady_clock::time_point, &peer_information::last_bootstrap_attempt>>,
+	boost::multi_index::ordered_non_unique<boost::multi_index::member<peer_information, std::chrono::steady_clock::time_point, &peer_information::last_rep_request>>,
 	boost::multi_index::ordered_non_unique<boost::multi_index::member<peer_information, rai::amount, &peer_information::rep_weight>, std::greater<rai::amount>>>>
 	peers;
 	boost::multi_index_container<
 	peer_attempt,
 	boost::multi_index::indexed_by<
 	boost::multi_index::hashed_unique<boost::multi_index::member<peer_attempt, rai::endpoint, &peer_attempt::endpoint>>,
-	boost::multi_index::ordered_non_unique<boost::multi_index::member<peer_attempt, std::chrono::system_clock::time_point, &peer_attempt::last_attempt>>>>
+	boost::multi_index::ordered_non_unique<boost::multi_index::member<peer_attempt, std::chrono::steady_clock::time_point, &peer_attempt::last_attempt>>>>
 	attempts;
 	// Called when a new peer is observed
 	std::function<void(rai::endpoint const &)> peer_observer;
@@ -277,7 +275,7 @@ public:
 class block_arrival_info
 {
 public:
-	std::chrono::system_clock::time_point arrival;
+	std::chrono::steady_clock::time_point arrival;
 	rai::block_hash hash;
 };
 // This class tracks blocks that are probably live because they arrived in a UDP packet
@@ -290,7 +288,7 @@ public:
 	boost::multi_index_container<
 	rai::block_arrival_info,
 	boost::multi_index::indexed_by<
-	boost::multi_index::ordered_non_unique<boost::multi_index::member<rai::block_arrival_info, std::chrono::system_clock::time_point, &rai::block_arrival_info::arrival>>,
+	boost::multi_index::ordered_non_unique<boost::multi_index::member<rai::block_arrival_info, std::chrono::steady_clock::time_point, &rai::block_arrival_info::arrival>>,
 	boost::multi_index::hashed_unique<boost::multi_index::member<rai::block_arrival_info, rai::block_hash, &rai::block_arrival_info::hash>>>>
 	arrival;
 	std::mutex mutex;
@@ -304,7 +302,7 @@ public:
 	void receive_action (boost::system::error_code const &, size_t);
 	void rpc_action (boost::system::error_code const &, size_t);
 	void rebroadcast_reps (std::shared_ptr<rai::block>);
-	void republish_vote (std::chrono::system_clock::time_point const &, std::shared_ptr<rai::vote>);
+	void republish_vote (std::chrono::steady_clock::time_point const &, std::shared_ptr<rai::vote>);
 	void republish_block (MDB_txn *, std::shared_ptr<rai::block>);
 	void republish (rai::block_hash const &, std::shared_ptr<std::vector<uint8_t>>, rai::endpoint);
 	void publish_broadcast (std::vector<rai::peer_information> &, std::unique_ptr<rai::block>);

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -4117,7 +4117,7 @@ void rai::rpc_connection::parse_connection ()
 		if (!ec)
 		{
 			this_l->node->background ([this_l]() {
-				auto start (std::chrono::system_clock::now ());
+				auto start (std::chrono::steady_clock::now ());
 				auto version (this_l->request.version ());
 				auto response_handler ([this_l, version, start](boost::property_tree::ptree const & tree_a) {
 					std::stringstream ostream;
@@ -4136,7 +4136,7 @@ void rai::rpc_connection::parse_connection ()
 					});
 					if (this_l->node->config.logging.log_rpc ())
 					{
-						BOOST_LOG (this_l->node->log) << boost::str (boost::format ("RPC request %2% completed in: %1% microseconds") % std::chrono::duration_cast<std::chrono::microseconds> (std::chrono::system_clock::now () - start).count () % boost::io::group (std::hex, std::showbase, reinterpret_cast<uintptr_t> (this_l.get ())));
+						BOOST_LOG (this_l->node->log) << boost::str (boost::format ("RPC request %2% completed in: %1% microseconds") % std::chrono::duration_cast<std::chrono::microseconds> (std::chrono::steady_clock::now () - start).count () % boost::io::group (std::hex, std::showbase, reinterpret_cast<uintptr_t> (this_l.get ())));
 					}
 				});
 				if (this_l->request.method () == boost::beast::http::verb::post)
@@ -4607,7 +4607,7 @@ response (response_a)
 void rai::payment_observer::start (uint64_t timeout)
 {
 	auto this_l (shared_from_this ());
-	rpc.node.alarm.add (std::chrono::system_clock::now () + std::chrono::milliseconds (timeout), [this_l]() {
+	rpc.node.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (timeout), [this_l]() {
 		this_l->complete (rai::payment_status::nothing);
 	});
 }

--- a/rai/node/testing.hpp
+++ b/rai/node/testing.hpp
@@ -51,7 +51,6 @@ public:
 	landing (rai::node &, std::shared_ptr<rai::wallet>, rai::landing_store &, boost::filesystem::path const &);
 	void write_store ();
 	rai::uint128_t distribution_amount (uint64_t);
-	uint64_t seconds_since_epoch ();
 	void distribute_one ();
 	void distribute_ongoing ();
 	boost::filesystem::path path;

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1199,11 +1199,11 @@ void rai::wallet::init_free_accounts (MDB_txn * transaction_a)
 
 void rai::wallet::work_generate (rai::account const & account_a, rai::block_hash const & root_a)
 {
-	auto begin (std::chrono::system_clock::now ());
+	auto begin (std::chrono::steady_clock::now ());
 	auto work (node.generate_work (root_a));
 	if (node.config.logging.work_generation_time ())
 	{
-		BOOST_LOG (node.log) << "Work generation complete: " << (std::chrono::duration_cast<std::chrono::microseconds> (std::chrono::system_clock::now () - begin).count ()) << " us";
+		BOOST_LOG (node.log) << "Work generation complete: " << (std::chrono::duration_cast<std::chrono::microseconds> (std::chrono::steady_clock::now () - begin).count ()) << " us";
 	}
 	rai::transaction transaction (store.environment, nullptr, true);
 	if (store.exists (transaction, account_a))
@@ -1364,10 +1364,10 @@ void rai::wallets::foreach_representative (MDB_txn * transaction_a, std::functio
 				}
 				else
 				{
-					static auto last_log = std::chrono::system_clock::time_point ();
-					if (last_log < std::chrono::system_clock::now () - std::chrono::seconds (60))
+					static auto last_log = std::chrono::steady_clock::time_point ();
+					if (last_log < std::chrono::steady_clock::now () - std::chrono::seconds (60))
 					{
-						last_log = std::chrono::system_clock::now ();
+						last_log = std::chrono::steady_clock::now ();
 						BOOST_LOG (node.log) << boost::str (boost::format ("Representative locked inside wallet %1%") % i->first.to_string ());
 					}
 				}

--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -249,7 +249,7 @@ void rai_qt::accounts::refresh_wallet_balance ()
 		final_text += "\nPending: " + wallet.format_balance (pending);
 	}
 	wallet_balance_label->setText (QString (final_text.c_str ()));
-	this->wallet.node.alarm.add (std::chrono::system_clock::now () + std::chrono::seconds (60), [this]() {
+	this->wallet.node.alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (60), [this]() {
 		this->wallet.application.postEvent (&this->wallet.processor, new eventloop_event ([this]() {
 			refresh_wallet_balance ();
 		}));
@@ -1200,7 +1200,7 @@ void rai_qt::wallet::update_connected ()
 
 void rai_qt::wallet::empty_password ()
 {
-	this->node.alarm.add (std::chrono::system_clock::now () + std::chrono::seconds (3), [this]() {
+	this->node.alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (3), [this]() {
 		wallet_m->enter_password (std::string (""));
 	});
 }

--- a/rai/qt_test/qt.cpp
+++ b/rai/qt_test/qt.cpp
@@ -53,7 +53,7 @@ TEST (wallet, status)
 		++iterations;
 		ASSERT_LT (iterations, 500);
 	}
-	system.nodes[0]->peers.purge_list (std::chrono::system_clock::now () + std::chrono::seconds (5));
+	system.nodes[0]->peers.purge_list (std::chrono::steady_clock::now () + std::chrono::seconds (5));
 	while (wallet_has (rai_qt::status_types::synchronizing))
 	{
 		test_application->processEvents ();

--- a/rai/secure.cpp
+++ b/rai/secure.cpp
@@ -1,6 +1,7 @@
 #include <rai/secure.hpp>
 
 #include <rai/lib/interface.h>
+#include <rai/node/common.hpp>
 #include <rai/node/working.hpp>
 #include <rai/versioning.hpp>
 
@@ -2306,7 +2307,7 @@ void rai::ledger::change_latest (MDB_txn * transaction_a, rai::account const & a
 		info.head = hash_a;
 		info.rep_block = rep_block_a;
 		info.balance = balance_a;
-		info.modified = store.now ();
+		info.modified = rai::seconds_since_epoch ();
 		info.block_count = block_count_a;
 		store.account_put (transaction_a, account_a, info);
 		if (!(block_count_a % store.block_info_max))
@@ -2666,7 +2667,7 @@ void rai::genesis::initialize (MDB_txn * transaction_a, rai::block_store & store
 	auto hash_l (hash ());
 	assert (store_a.latest_begin (transaction_a) == store_a.latest_end ());
 	store_a.block_put (transaction_a, hash_l, *open);
-	store_a.account_put (transaction_a, genesis_account, { hash_l, open->hash (), open->hash (), std::numeric_limits<rai::uint128_t>::max (), store_a.now (), 1 });
+	store_a.account_put (transaction_a, genesis_account, { hash_l, open->hash (), open->hash (), std::numeric_limits<rai::uint128_t>::max (), rai::seconds_since_epoch (), 1 });
 	store_a.representation_put (transaction_a, genesis_account, std::numeric_limits<rai::uint128_t>::max ());
 	store_a.checksum_put (transaction_a, 0, 0, hash_l);
 	store_a.frontier_put (transaction_a, hash_l, genesis_account);

--- a/rai/secure.hpp
+++ b/rai/secure.hpp
@@ -55,6 +55,7 @@ public:
 	rai::block_hash rep_block;
 	rai::block_hash open_block;
 	rai::amount balance;
+	/** Seconds since posix epoch */
 	uint64_t modified;
 	uint64_t block_count;
 };
@@ -174,7 +175,6 @@ class block_store
 {
 public:
 	block_store (bool &, boost::filesystem::path const &, int lmdb_max_dbs = 128);
-	uint64_t now ();
 
 	MDB_dbi block_database (rai::block_type);
 	void block_put_raw (MDB_txn *, MDB_dbi, rai::block_hash const &, MDB_val);

--- a/rai/slow_test/node.cpp
+++ b/rai/slow_test/node.cpp
@@ -58,7 +58,7 @@ TEST (system, receive_while_synchronizing)
 		auto wallet (node1->wallets.create (1));
 		ASSERT_EQ (key.pub, wallet->insert_adhoc (key.prv));
 		node1->start ();
-		system.alarm.add (std::chrono::system_clock::now () + std::chrono::milliseconds (200), ([&system, &key]() {
+		system.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (200), ([&system, &key]() {
 			auto hash (system.wallet (0)->send_sync (rai::test_genesis_key.pub, key.pub, system.nodes[0]->config.receive_minimum.number ()));
 			auto block (system.nodes[0]->store.block_get (rai::transaction (system.nodes[0]->store.environment, nullptr, false), hash));
 			std::string block_text;
@@ -362,17 +362,17 @@ TEST (peer_container, random_set)
 	{
 		container.contacted (rai::endpoint (loopback, 24001 + i), 0);
 	}
-	auto old (std::chrono::system_clock::now ());
+	auto old (std::chrono::steady_clock::now ());
 	for (auto i (0); i < 10000; ++i)
 	{
 		auto list (container.list_sqrt ());
 	}
-	auto current (std::chrono::system_clock::now ());
+	auto current (std::chrono::steady_clock::now ());
 	for (auto i (0); i < 10000; ++i)
 	{
 		auto list (container.random_set (15));
 	}
-	auto end (std::chrono::system_clock::now ());
+	auto end (std::chrono::steady_clock::now ());
 	auto old_ms (std::chrono::duration_cast<std::chrono::milliseconds> (current - old));
 	auto new_ms (std::chrono::duration_cast<std::chrono::milliseconds> (end - current));
 }


### PR DESCRIPTION
This PR deals with time:

* There were two different seconds-since-epoch implementations, one using std::chrono, the other using boost::posix_time. I've factored out the chrono approach into common.hpp and updated all call sites to use that one (both approaches produced the same result)

* Using `system_clock` for measuring durations is problematic, since the system clock may jump (for instance when NTP kicks in, or DST transitions). `steady_clock` is thus used instead.

* Removed an ostream `operator<<` taking a system_clock which was never used.

I don't think any of the code depends on wall time (except seconds_since_epoch), but please verify this.