### PR TITLE
Remove `apt-get install cargo` in build-travis.sh

### DIFF
--- a/ci/build-travis.sh
+++ b/ci/build-travis.sh
@@ -48,12 +48,6 @@ else
     TRUE_CMD=true
 fi
 
-if ! cargo --version &>/dev/null; then
-    # We'll update the docker image once this PR gets merged.
-    # If you're reading this comment on master, contact @PlasmaPower
-    apt-get update && apt-get install -yq cargo
-fi
-
 pushd load-tester
 cargo build --release
 popd


### PR DESCRIPTION
Once @lukealonso has updated the docker image, this will no longer be necessary.