### PR TITLE
Clean up and fix docker

### DIFF
--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -8,18 +8,16 @@ RUN apt-get update && apt-get install -yq \
     build-essential \
     cmake \
     g++ \
-    wget
-
-WORKDIR "/tmp"
-
-RUN wget -O ${BOOST_BASENAME}.tar.gz ${BOOST_URL} && \
+    wget && \
+    wget -O ${BOOST_BASENAME}.tar.gz ${BOOST_URL} && \
     tar xzvf ${BOOST_BASENAME}.tar.gz && \
     cd ${BOOST_BASENAME} && \
     ./bootstrap.sh && \
     ./b2 --prefix=${BOOST_ROOT} link=static install && \
     rm -rf ${BOOST_BASENAME} && \
     rm -f ${BOOST_BASENAME}.tar.gz && \
-    cd ..
+    cd .. && \
+    mkdir /usr/share/raiblocks/
 
 ADD ./ /tmp/src
 
@@ -31,5 +29,7 @@ RUN mkdir /tmp/build && \
 
 FROM ubuntu:16.04
 COPY --from=0 /tmp/build/rai_node /usr/bin
-COPY --from=0 /tmp/build/librai_lib.so /usr/bin
-CMD ["rai_node", "--daemon"]
+COPY docker/node/entry.sh /entry.sh
+COPY docker/node/config.json /usr/share/raiblocks/config.json
+RUN chmod +x /entry.sh
+CMD ["/bin/bash",  "/entry.sh"]

--- a/docker/node/config.json
+++ b/docker/node/config.json
@@ -1,0 +1,67 @@
+{
+    "version": "2",
+    "rpc_enable": "true",
+    "rpc": {
+        "address": "::ffff:0.0.0.0",
+        "port": "7076",
+        "enable_control": "true",
+        "frontier_request_limit": "16384",
+        "chain_request_limit": "16384"
+    },
+    "node": {
+        "version": "8",
+        "peering_port": "7075",
+        "bootstrap_fraction_numerator": "1",
+        "receive_minimum": "1000000000000000000000000",
+        "logging": {
+            "version": "2",
+            "ledger": "false",
+            "ledger_duplicate": "false",
+            "vote": "false",
+            "network": "true",
+            "network_message": "false",
+            "network_publish": "false",
+            "network_packet": "false",
+            "network_keepalive": "false",
+            "node_lifetime_tracing": "false",
+            "insufficient_work": "true",
+            "log_rpc": "true",
+            "bulk_pull": "false",
+            "work_generation_time": "true",
+            "log_to_cerr": "false",
+            "max_size": "16777216",
+            "rotation_size": "4194304",
+            "flush": "false"
+        },
+        "work_peers": "",
+        "preconfigured_peers": [
+            "rai.raiblocks.net"
+        ],
+        "preconfigured_representatives": [
+            "xrb_3arg3asgtigae3xckabaaewkx3bzsh7nwz7jkmjos79ihyaxwphhm6qgjps4",
+            "xrb_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou",
+            "xrb_1q3hqecaw15cjt7thbtxu3pbzr1eihtzzpzxguoc37bj1wc5ffoh7w74gi6p",
+            "xrb_3dmtrrws3pocycmbqwawk6xs7446qxa36fcncush4s1pejk16ksbmakis78m",
+            "xrb_3hd4ezdgsp15iemx7h81in7xz5tpxi43b6b41zn3qmwiuypankocw3awes5k",
+            "xrb_1awsn43we17c1oshdru4azeqjz9wii41dy8npubm4rg11so7dx3jtqgoeahy",
+            "xrb_1anrzcuwe64rwxzcco8dkhpyxpi8kd7zsjc1oeimpc3ppca4mrjtwnqposrs",
+            "xrb_1hza3f7wiiqa7ig3jczyxj5yo86yegcmqk3criaz838j91sxcckpfhbhhra1"
+        ],
+        "inactive_supply": "0",
+        "password_fanout": "1024",
+        "io_threads": "4",
+        "work_threads": "4",
+        "enable_voting": "true",
+        "bootstrap_connections": "16",
+        "callback_address": "",
+        "callback_port": "0",
+        "callback_target": "",
+        "lmdb_max_dbs": "128"
+    },
+    "opencl_enable": "false",
+    "opencl": {
+        "platform": "0",
+        "device": "0",
+        "threads": "1048576"
+    }
+}

--- a/docker/node/entry.sh
+++ b/docker/node/entry.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+mkdir -p ~/RaiBlocks
+if [ ! -f ~/RaiBlocks/config.json ]; then
+  echo "Config File not found, adding default."
+  cp /usr/share/raiblocks/config.json ~/RaiBlocks/
+fi
+/usr/bin/rai_node --daemon


### PR DESCRIPTION
Don't try and copy .so as rai_node is static.
Put default json config in docker.
Add entry point for cmd
Clean up the dockerfile to have fewer build steps

This should fix #502 but will need to change the wiki once it's in and the new docker image is published.