### PR TITLE
Make slow log flushing optional

### DIFF
--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -546,7 +546,8 @@ log_rpc_value (true),
 bulk_pull_logging_value (false),
 work_generation_time_value (true),
 log_to_cerr_value (false),
-max_size (16 * 1024 * 1024)
+max_size (16 * 1024 * 1024),
+flush (true)
 {
 }
 
@@ -560,7 +561,7 @@ void rai::logging::init (boost::filesystem::path const & application_path_a)
 		{
 			boost::log::add_console_log (std::cerr, boost::log::keywords::format = "[%TimeStamp%]: %Message%");
 		}
-		boost::log::add_file_log (boost::log::keywords::target = application_path_a / "log", boost::log::keywords::file_name = application_path_a / "log" / "log_%Y-%m-%d_%H-%M-%S.%N.log", boost::log::keywords::rotation_size = 4 * 1024 * 1024, boost::log::keywords::auto_flush = true, boost::log::keywords::scan_method = boost::log::sinks::file::scan_method::scan_matching, boost::log::keywords::max_size = max_size, boost::log::keywords::format = "[%TimeStamp%]: %Message%");
+		boost::log::add_file_log (boost::log::keywords::target = application_path_a / "log", boost::log::keywords::file_name = application_path_a / "log" / "log_%Y-%m-%d_%H-%M-%S.%N.log", boost::log::keywords::rotation_size = 4 * 1024 * 1024, boost::log::keywords::auto_flush = flush, boost::log::keywords::scan_method = boost::log::sinks::file::scan_method::scan_matching, boost::log::keywords::max_size = max_size, boost::log::keywords::format = "[%TimeStamp%]: %Message%");
 	}
 }
 
@@ -582,6 +583,7 @@ void rai::logging::serialize_json (boost::property_tree::ptree & tree_a) const
 	tree_a.put ("work_generation_time", work_generation_time_value);
 	tree_a.put ("log_to_cerr", log_to_cerr_value);
 	tree_a.put ("max_size", max_size);
+	tree_a.put ("flush", flush);
 }
 
 bool rai::logging::upgrade_json (unsigned version_a, boost::property_tree::ptree & tree_a)
@@ -635,6 +637,7 @@ bool rai::logging::deserialize_json (bool & upgraded_a, boost::property_tree::pt
 		work_generation_time_value = tree_a.get<bool> ("work_generation_time");
 		log_to_cerr_value = tree_a.get<bool> ("log_to_cerr");
 		max_size = tree_a.get<uintmax_t> ("max_size");
+		flush = tree_a.get<bool> ("flush", true);
 	}
 	catch (std::runtime_error const &)
 	{

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -365,6 +365,7 @@ public:
 	bool bulk_pull_logging_value;
 	bool work_generation_time_value;
 	bool log_to_cerr_value;
+	bool flush;
 	uintmax_t max_size;
 	boost::log::sources::logger_mt log;
 };


### PR DESCRIPTION
Logging currently flushes every single log record to disk. While nice for diagnosing crashes, this is very very slow, even on my ssd. In one io completion handler I measured, a third of the time was spent logging, and most of that was flushing.

This PR proposes a new logging config flag called `"flush"`. I've kept the conservative default of true, so nothing changes until you set it to false. 

I do think it should be default false in the future, as people can always flip the switch to diagnose crashes. Or should I make default false already now?

If this is merged, the config wiki needs to be updated.