### PR TITLE
Avoid bootstrapping from stuck nodes.

### DIFF
--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -5,6 +5,9 @@
 
 #include <boost/log/trivial.hpp>
 
+// Updated 1-27-18
+constexpr unsigned bootstrap_peer_frontier_minimum = rai::rai_network == rai::rai_networks::rai_live_network ? 339000 : 0;
+
 rai::block_synchronization::block_synchronization (boost::log::sources::logger_mt & log_a) :
 log (log_a)
 {
@@ -420,7 +423,7 @@ void rai::frontier_req_client::received_frontier (boost::system::error_code cons
 			{
 				try
 				{
-					promise.set_value (false);
+					promise.set_value (count < bootstrap_peer_frontier_minimum);
 				}
 				catch (std::future_error &)
 				{


### PR DESCRIPTION
This patch introduces a hardcoded checkpoint on the number of frontiers a node should know about before we pull based on the frontiers it provides. This number should monotonically increase with node releases.

There are many stuck nodes with 8000-2M checked blocks in the network, and it's both a waste of time and a potential source of unresolvable forks to pull from them.

This is the smallest of 4 changes to get 100% reliable bootstrapping from zero in ~30 minutes.

Note: This isn't meant to and will not help with any kind of bootstrap poisoning attack, it simply helps with a real problem on the live network.