### PR TITLE
Force resolution of forks during bootstrap.

### DIFF
--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -1184,7 +1184,7 @@ TEST (node, rep_self_vote)
 	auto & active (node0->active);
 	{
 		rai::transaction transaction (node0->store.environment, nullptr, true);
-		active.start (transaction, block0, [](std::shared_ptr<rai::block>) {});
+		active.start (transaction, block0, [](std::shared_ptr<rai::block>, bool) {});
 	}
 	auto existing (active.roots.find (block0->root ()));
 	ASSERT_NE (active.roots.end (), existing);

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -88,6 +88,8 @@ public:
 	void add_pull (rai::pull_info const &);
 	bool still_pulling ();
 	void process_fork (MDB_txn *, std::shared_ptr<rai::block>);
+	void try_resolve_fork (MDB_txn *, std::shared_ptr<rai::block>, bool);
+	void resolve_forks ();
 	unsigned target_connections (size_t pulls_remaining);
 	std::deque<std::weak_ptr<rai::bootstrap_client>> clients;
 	std::weak_ptr<rai::bootstrap_client> connection_frontier_request;
@@ -100,6 +102,7 @@ public:
 	std::shared_ptr<rai::node> node;
 	std::atomic<unsigned> account_count;
 	std::atomic<uint64_t> total_blocks;
+	std::unordered_map<rai::block_hash, std::shared_ptr<rai::block>> unresolved_forks;
 	bool stopped;
 	std::mutex mutex;
 	std::condition_variable condition;

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1320,7 +1320,11 @@ rai::process_return rai::block_processor::process_receive_one (MDB_txn * transac
 		}
 		case rai::process_result::fork:
 		{
-			node.bootstrap_initiator.process_fork (transaction_a, block_a);
+			if (!node.block_arrival.recent (block_a->hash ()))
+			{
+				// Only let the bootstrap attempt know about forked blocks that did not arrive via UDP.
+				node.bootstrap_initiator.process_fork (transaction_a, block_a);
+			}
 			if (node.config.logging.ledger_logging ())
 			{
 				BOOST_LOG (node.log) << boost::str (boost::format ("Fork for: %1% root: %2%") % block_a->hash ().to_string () % block_a->root ().to_string ());
@@ -2698,7 +2702,7 @@ std::shared_ptr<rai::node> rai::node::shared ()
 	return shared_from_this ();
 }
 
-rai::election::election (MDB_txn * transaction_a, rai::node & node_a, std::shared_ptr<rai::block> block_a, std::function<void(std::shared_ptr<rai::block>)> const & confirmation_action_a) :
+rai::election::election (MDB_txn * transaction_a, rai::node & node_a, std::shared_ptr<rai::block> block_a, std::function<void(std::shared_ptr<rai::block>, bool)> const & confirmation_action_a) :
 confirmation_action (confirmation_action_a),
 votes (block_a),
 node (node_a),
@@ -2748,9 +2752,10 @@ void rai::election::confirm_once (MDB_txn * transaction_a)
 		assert (tally_l.size () > 0);
 		auto winner (tally_l.begin ());
 		auto block_l (winner->second);
+		auto exceeded_min_threshold = winner->first > minimum_threshold (transaction_a, node.ledger);
 		if (!(*block_l == *last_winner))
 		{
-			if (winner->first > minimum_threshold (transaction_a, node.ledger))
+			if (exceeded_min_threshold)
 			{
 				auto node_l (node.shared ());
 				node.background ([node_l, block_l]() {
@@ -2766,9 +2771,9 @@ void rai::election::confirm_once (MDB_txn * transaction_a)
 		auto winner_l (last_winner);
 		auto node_l (node.shared ());
 		auto confirmation_action_l (confirmation_action);
-		node.background ([winner_l, confirmation_action_l, node_l]() {
+		node.background ([winner_l, confirmation_action_l, node_l, exceeded_min_threshold]() {
 			node_l->process_confirmed (winner_l);
-			confirmation_action_l (winner_l);
+			confirmation_action_l (winner_l, exceeded_min_threshold);
 		});
 	}
 }
@@ -2875,7 +2880,7 @@ void rai::active_transactions::stop ()
 	roots.clear ();
 }
 
-bool rai::active_transactions::start (MDB_txn * transaction_a, std::shared_ptr<rai::block> block_a, std::function<void(std::shared_ptr<rai::block>)> const & confirmation_action_a)
+bool rai::active_transactions::start (MDB_txn * transaction_a, std::shared_ptr<rai::block> block_a, std::function<void(std::shared_ptr<rai::block>, bool)> const & confirmation_action_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
 	auto root (block_a->root ());

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -37,11 +37,11 @@ namespace rai
 class node;
 class election : public std::enable_shared_from_this<rai::election>
 {
-	std::function<void(std::shared_ptr<rai::block>)> confirmation_action;
+	std::function<void(std::shared_ptr<rai::block>, bool)> confirmation_action;
 	void confirm_once (MDB_txn *);
 
 public:
-	election (MDB_txn *, rai::node &, std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>)> const &);
+	election (MDB_txn *, rai::node &, std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>, bool)> const &);
 	void vote (std::shared_ptr<rai::vote>);
 	// Check if we have vote quorum
 	bool have_quorum (MDB_txn *);
@@ -77,7 +77,7 @@ public:
 	active_transactions (rai::node &);
 	// Start an election for a block
 	// Call action with confirmed block, may be different than what we started with
-	bool start (MDB_txn *, std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>)> const & = [](std::shared_ptr<rai::block>) {});
+	bool start (MDB_txn *, std::shared_ptr<rai::block>, std::function<void(std::shared_ptr<rai::block>, bool)> const & = [](std::shared_ptr<rai::block>, bool) {});
 	void vote (std::shared_ptr<rai::vote>);
 	// Is the root of this block in the roots container
 	bool active (rai::block const &);

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1112,7 +1112,7 @@ public:
 						std::shared_ptr<rai::block> block_l (wallet->node.store.block_get (transaction, info.head));
 						wallet->node.background ([this_l, account, block_l] {
 							rai::transaction transaction (this_l->wallet->node.store.environment, nullptr, true);
-							this_l->wallet->node.active.start (transaction, block_l, [this_l, account](std::shared_ptr<rai::block>) {
+							this_l->wallet->node.active.start (transaction, block_l, [this_l, account](std::shared_ptr<rai::block>, bool) {
 								// If there were any forks for this account they've been rolled back and we can receive anything remaining from this account
 								this_l->receive_all (account);
 							});


### PR DESCRIPTION
This patch adds unresolved fork tracking to the bootstrapper. It will continue to try to resolve the forked blocks until it succeeds, or the bootstrap finishes (likely stalled if there are any unresolved forks).

A single unresolved fork can mean the bootstrap will stall with a few million unchecked blocks.