### PR TITLE
Rename result to more descriptive names

### DIFF
--- a/rai/lib/blocks.cpp
+++ b/rai/lib/blocks.cpp
@@ -10,11 +10,11 @@ std::string rai::to_string_hex (uint64_t value_a)
 
 bool rai::from_string_hex (std::string const & value_a, uint64_t & target_a)
 {
-	auto result (value_a.empty ());
-	if (!result)
+	auto error (value_a.empty ());
+	if (!error)
 	{
-		result = value_a.size () > 16;
-		if (!result)
+		error = value_a.size () > 16;
+		if (!error)
 		{
 			std::stringstream stream (value_a);
 			stream << std::hex << std::noshowbase;
@@ -25,16 +25,16 @@ bool rai::from_string_hex (std::string const & value_a, uint64_t & target_a)
 				target_a = number_l;
 				if (!stream.eof ())
 				{
-					result = true;
+					error = true;
 				}
 			}
 			catch (std::runtime_error &)
 			{
-				result = true;
+				error = true;
 			}
 		}
 	}
-	return result;
+	return error;
 }
 
 rai::block::~block ()
@@ -164,30 +164,30 @@ void rai::send_block::serialize_json (std::string & string_a) const
 
 bool rai::send_block::deserialize (rai::stream & stream_a)
 {
-	auto result (false);
-	result = read (stream_a, hashables.previous.bytes);
-	if (!result)
+	auto error (false);
+	error = read (stream_a, hashables.previous.bytes);
+	if (!error)
 	{
-		result = read (stream_a, hashables.destination.bytes);
-		if (!result)
+		error = read (stream_a, hashables.destination.bytes);
+		if (!error)
 		{
-			result = read (stream_a, hashables.balance.bytes);
-			if (!result)
+			error = read (stream_a, hashables.balance.bytes);
+			if (!error)
 			{
-				result = read (stream_a, signature.bytes);
-				if (!result)
+				error = read (stream_a, signature.bytes);
+				if (!error)
 				{
-					result = read (stream_a, work);
+					error = read (stream_a, work);
 				}
 			}
 		}
 	}
-	return result;
+	return error;
 }
 
 bool rai::send_block::deserialize_json (boost::property_tree::ptree const & tree_a)
 {
-	auto result (false);
+	auto error (false);
 	try
 	{
 		assert (tree_a.get<std::string> ("type") == "send");
@@ -196,19 +196,19 @@ bool rai::send_block::deserialize_json (boost::property_tree::ptree const & tree
 		auto balance_l (tree_a.get<std::string> ("balance"));
 		auto work_l (tree_a.get<std::string> ("work"));
 		auto signature_l (tree_a.get<std::string> ("signature"));
-		result = hashables.previous.decode_hex (previous_l);
-		if (!result)
+		error = hashables.previous.decode_hex (previous_l);
+		if (!error)
 		{
-			result = hashables.destination.decode_account (destination_l);
-			if (!result)
+			error = hashables.destination.decode_account (destination_l);
+			if (!error)
 			{
-				result = hashables.balance.decode_hex (balance_l);
-				if (!result)
+				error = hashables.balance.decode_hex (balance_l);
+				if (!error)
 				{
-					result = rai::from_string_hex (work_l, work);
-					if (!result)
+					error = rai::from_string_hex (work_l, work);
+					if (!error)
 					{
-						result = signature.decode_hex (signature_l);
+						error = signature.decode_hex (signature_l);
 					}
 				}
 			}
@@ -216,9 +216,9 @@ bool rai::send_block::deserialize_json (boost::property_tree::ptree const & tree
 	}
 	catch (std::runtime_error const &)
 	{
-		result = true;
+		error = true;
 	}
-	return result;
+	return error;
 }
 
 rai::send_block::send_block (rai::block_hash const & previous_a, rai::account const & destination_a, rai::amount const & balance_a, rai::raw_key const & prv_a, rai::public_key const & pub_a, uint64_t work_a) :
@@ -458,29 +458,29 @@ void rai::open_block::serialize_json (std::string & string_a) const
 
 bool rai::open_block::deserialize (rai::stream & stream_a)
 {
-	auto result (read (stream_a, hashables.source));
-	if (!result)
+	auto error (read (stream_a, hashables.source));
+	if (!error)
 	{
-		result = read (stream_a, hashables.representative);
-		if (!result)
+		error = read (stream_a, hashables.representative);
+		if (!error)
 		{
-			result = read (stream_a, hashables.account);
-			if (!result)
+			error = read (stream_a, hashables.account);
+			if (!error)
 			{
-				result = read (stream_a, signature);
-				if (!result)
+				error = read (stream_a, signature);
+				if (!error)
 				{
-					result = read (stream_a, work);
+					error = read (stream_a, work);
 				}
 			}
 		}
 	}
-	return result;
+	return error;
 }
 
 bool rai::open_block::deserialize_json (boost::property_tree::ptree const & tree_a)
 {
-	auto result (false);
+	auto error (false);
 	try
 	{
 		assert (tree_a.get<std::string> ("type") == "open");
@@ -489,19 +489,19 @@ bool rai::open_block::deserialize_json (boost::property_tree::ptree const & tree
 		auto account_l (tree_a.get<std::string> ("account"));
 		auto work_l (tree_a.get<std::string> ("work"));
 		auto signature_l (tree_a.get<std::string> ("signature"));
-		result = hashables.source.decode_hex (source_l);
-		if (!result)
+		error = hashables.source.decode_hex (source_l);
+		if (!error)
 		{
-			result = hashables.representative.decode_hex (representative_l);
-			if (!result)
+			error = hashables.representative.decode_hex (representative_l);
+			if (!error)
 			{
-				result = hashables.account.decode_hex (account_l);
-				if (!result)
+				error = hashables.account.decode_hex (account_l);
+				if (!error)
 				{
-					result = rai::from_string_hex (work_l, work);
-					if (!result)
+					error = rai::from_string_hex (work_l, work);
+					if (!error)
 					{
-						result = signature.decode_hex (signature_l);
+						error = signature.decode_hex (signature_l);
 					}
 				}
 			}
@@ -509,9 +509,9 @@ bool rai::open_block::deserialize_json (boost::property_tree::ptree const & tree
 	}
 	catch (std::runtime_error const &)
 	{
-		result = true;
+		error = true;
 	}
-	return result;
+	return error;
 }
 
 void rai::open_block::visit (rai::block_visitor & visitor_a) const
@@ -686,25 +686,25 @@ void rai::change_block::serialize_json (std::string & string_a) const
 
 bool rai::change_block::deserialize (rai::stream & stream_a)
 {
-	auto result (read (stream_a, hashables.previous));
-	if (!result)
+	auto error (read (stream_a, hashables.previous));
+	if (!error)
 	{
-		result = read (stream_a, hashables.representative);
-		if (!result)
+		error = read (stream_a, hashables.representative);
+		if (!error)
 		{
-			result = read (stream_a, signature);
-			if (!result)
+			error = read (stream_a, signature);
+			if (!error)
 			{
-				result = read (stream_a, work);
+				error = read (stream_a, work);
 			}
 		}
 	}
-	return result;
+	return error;
 }
 
 bool rai::change_block::deserialize_json (boost::property_tree::ptree const & tree_a)
 {
-	auto result (false);
+	auto error (false);
 	try
 	{
 		assert (tree_a.get<std::string> ("type") == "change");
@@ -712,25 +712,25 @@ bool rai::change_block::deserialize_json (boost::property_tree::ptree const & tr
 		auto representative_l (tree_a.get<std::string> ("representative"));
 		auto work_l (tree_a.get<std::string> ("work"));
 		auto signature_l (tree_a.get<std::string> ("signature"));
-		result = hashables.previous.decode_hex (previous_l);
-		if (!result)
+		error = hashables.previous.decode_hex (previous_l);
+		if (!error)
 		{
-			result = hashables.representative.decode_hex (representative_l);
-			if (!result)
+			error = hashables.representative.decode_hex (representative_l);
+			if (!error)
 			{
-				result = rai::from_string_hex (work_l, work);
-				if (!result)
+				error = rai::from_string_hex (work_l, work);
+				if (!error)
 				{
-					result = signature.decode_hex (signature_l);
+					error = signature.decode_hex (signature_l);
 				}
 			}
 		}
 	}
 	catch (std::runtime_error const &)
 	{
-		result = true;
+		error = true;
 	}
-	return result;
+	return error;
 }
 
 void rai::change_block::visit (rai::block_visitor & visitor_a) const
@@ -905,26 +905,26 @@ bool rai::receive_block::operator== (rai::receive_block const & other_a) const
 
 bool rai::receive_block::deserialize (rai::stream & stream_a)
 {
-	auto result (false);
-	result = read (stream_a, hashables.previous.bytes);
-	if (!result)
+	auto error (false);
+	error = read (stream_a, hashables.previous.bytes);
+	if (!error)
 	{
-		result = read (stream_a, hashables.source.bytes);
-		if (!result)
+		error = read (stream_a, hashables.source.bytes);
+		if (!error)
 		{
-			result = read (stream_a, signature.bytes);
-			if (!result)
+			error = read (stream_a, signature.bytes);
+			if (!error)
 			{
-				result = read (stream_a, work);
+				error = read (stream_a, work);
 			}
 		}
 	}
-	return result;
+	return error;
 }
 
 bool rai::receive_block::deserialize_json (boost::property_tree::ptree const & tree_a)
 {
-	auto result (false);
+	auto error (false);
 	try
 	{
 		assert (tree_a.get<std::string> ("type") == "receive");
@@ -932,25 +932,25 @@ bool rai::receive_block::deserialize_json (boost::property_tree::ptree const & t
 		auto source_l (tree_a.get<std::string> ("source"));
 		auto work_l (tree_a.get<std::string> ("work"));
 		auto signature_l (tree_a.get<std::string> ("signature"));
-		result = hashables.previous.decode_hex (previous_l);
-		if (!result)
+		error = hashables.previous.decode_hex (previous_l);
+		if (!error)
 		{
-			result = hashables.source.decode_hex (source_l);
-			if (!result)
+			error = hashables.source.decode_hex (source_l);
+			if (!error)
 			{
-				result = rai::from_string_hex (work_l, work);
-				if (!result)
+				error = rai::from_string_hex (work_l, work);
+				if (!error)
 				{
-					result = signature.decode_hex (signature_l);
+					error = signature.decode_hex (signature_l);
 				}
 			}
 		}
 	}
 	catch (std::runtime_error const &)
 	{
-		result = true;
+		error = true;
 	}
-	return result;
+	return error;
 }
 
 void rai::receive_block::serialize (rai::stream & stream_a) const

--- a/rai/lib/interface.cpp
+++ b/rai/lib/interface.cpp
@@ -37,24 +37,21 @@ int xrb_uint256_from_string (const char * source, xrb_uint256 destination)
 {
 	auto & number (*reinterpret_cast<rai::uint256_union *> (destination));
 	auto error (number.decode_hex (source));
-	auto result (error ? 1 : 0);
-	return result;
+	return error ? 1 : 0;
 }
 
 int xrb_uint512_from_string (const char * source, xrb_uint512 destination)
 {
 	auto & number (*reinterpret_cast<rai::uint512_union *> (destination));
 	auto error (number.decode_hex (source));
-	auto result (error ? 1 : 0);
-	return result;
+	return error ? 1 : 0;
 }
 
 int xrb_valid_address (const char * account_a)
 {
 	rai::uint256_union account;
 	auto error (account.decode_account (account_a));
-	auto result (error ? 1 : 0);
-	return result;
+	return error ? 1 : 0;
 }
 
 void xrb_generate_random (xrb_uint256 seed)

--- a/rai/lib/numbers.cpp
+++ b/rai/lib/numbers.cpp
@@ -75,68 +75,68 @@ std::string rai::uint256_union::to_account () const
 
 bool rai::uint256_union::decode_account_v1 (std::string const & source_a)
 {
-	auto result (source_a.size () != 50);
-	if (!result)
+	auto error (source_a.size () != 50);
+	if (!error)
 	{
 		rai::uint512_t number_l;
-		for (auto i (source_a.begin ()), j (source_a.end ()); !result && i != j; ++i)
+		for (auto i (source_a.begin ()), j (source_a.end ()); !error && i != j; ++i)
 		{
 			uint8_t character (*i);
-			result = character < 0x30 || character >= 0x80;
-			if (!result)
+			error = character < 0x30 || character >= 0x80;
+			if (!error)
 			{
 				uint8_t byte (base58_decode (character));
-				result = byte == '~';
-				if (!result)
+				error = byte == '~';
+				if (!error)
 				{
 					number_l *= 58;
 					number_l += byte;
 				}
 			}
 		}
-		if (!result)
+		if (!error)
 		{
 			*this = number_l.convert_to<rai::uint256_t> ();
 			uint32_t check ((number_l >> 256).convert_to<uint32_t> ());
-			result = (number_l >> (256 + 32)) != 13;
-			if (!result)
+			error = (number_l >> (256 + 32)) != 13;
+			if (!error)
 			{
 				uint32_t validation;
 				blake2b_state hash;
 				blake2b_init (&hash, sizeof (validation));
 				blake2b_update (&hash, bytes.data (), sizeof (bytes));
 				blake2b_final (&hash, reinterpret_cast<uint8_t *> (&validation), sizeof (validation));
-				result = check != validation;
+				error = check != validation;
 			}
 		}
 	}
-	return result;
+	return error;
 }
 
 bool rai::uint256_union::decode_account (std::string const & source_a)
 {
-	auto result (source_a.size () != 64);
-	if (!result)
+	auto error (source_a.size () != 64);
+	if (!error)
 	{
 		if (source_a[0] == 'x' && source_a[1] == 'r' && source_a[2] == 'b' && (source_a[3] == '_' || source_a[3] == '-'))
 		{
 			rai::uint512_t number_l;
-			for (auto i (source_a.begin () + 4), j (source_a.end ()); !result && i != j; ++i)
+			for (auto i (source_a.begin () + 4), j (source_a.end ()); !error && i != j; ++i)
 			{
 				uint8_t character (*i);
-				result = character < 0x30 || character >= 0x80;
-				if (!result)
+				error = character < 0x30 || character >= 0x80;
+				if (!error)
 				{
 					uint8_t byte (account_decode (character));
-					result = byte == '~';
-					if (!result)
+					error = byte == '~';
+					if (!error)
 					{
 						number_l <<= 5;
 						number_l += byte;
 					}
 				}
 			}
-			if (!result)
+			if (!error)
 			{
 				*this = (number_l >> 40).convert_to<rai::uint256_t> ();
 				uint64_t check (number_l.convert_to<uint64_t> ());
@@ -146,19 +146,19 @@ bool rai::uint256_union::decode_account (std::string const & source_a)
 				blake2b_init (&hash, 5);
 				blake2b_update (&hash, bytes.data (), bytes.size ());
 				blake2b_final (&hash, reinterpret_cast<uint8_t *> (&validation), 5);
-				result = check != validation;
+				error = check != validation;
 			}
 		}
 		else
 		{
-			result = true;
+			error = true;
 		}
 	}
 	else
 	{
-		result = decode_account_v1 (source_a);
+		error = decode_account_v1 (source_a);
 	}
-	return result;
+	return error;
 }
 
 rai::uint256_union::uint256_union (rai::uint256_t const & number_a)
@@ -256,7 +256,7 @@ void rai::uint256_union::encode_hex (std::string & text) const
 
 bool rai::uint256_union::decode_hex (std::string const & text)
 {
-	auto result (false);
+	auto error (false);
 	if (!text.empty () && text.size () <= 64)
 	{
 		std::stringstream stream (text);
@@ -268,19 +268,19 @@ bool rai::uint256_union::decode_hex (std::string const & text)
 			*this = number_l;
 			if (!stream.eof ())
 			{
-				result = true;
+				error = true;
 			}
 		}
 		catch (std::runtime_error &)
 		{
-			result = true;
+			error = true;
 		}
 	}
 	else
 	{
-		result = true;
+		error = true;
 	}
-	return result;
+	return error;
 }
 
 void rai::uint256_union::encode_dec (std::string & text) const
@@ -294,8 +294,8 @@ void rai::uint256_union::encode_dec (std::string & text) const
 
 bool rai::uint256_union::decode_dec (std::string const & text)
 {
-	auto result (text.size () > 78 || (text.size () > 1 && text[0] == '0') || (text.size () > 0 && text[0] == '-'));
-	if (!result)
+	auto error (text.size () > 78 || (text.size () > 1 && text[0] == '0') || (text.size () > 0 && text[0] == '-'));
+	if (!error)
 	{
 		std::stringstream stream (text);
 		stream << std::dec << std::noshowbase;
@@ -306,15 +306,15 @@ bool rai::uint256_union::decode_dec (std::string const & text)
 			*this = number_l;
 			if (!stream.eof ())
 			{
-				result = true;
+				error = true;
 			}
 		}
 		catch (std::runtime_error &)
 		{
-			result = true;
+			error = true;
 		}
 	}
-	return result;
+	return error;
 }
 
 rai::uint256_union::uint256_union (uint64_t value0)
@@ -371,8 +371,8 @@ void rai::uint512_union::encode_hex (std::string & text) const
 
 bool rai::uint512_union::decode_hex (std::string const & text)
 {
-	auto result (text.size () > 128);
-	if (!result)
+	auto error (text.size () > 128);
+	if (!error)
 	{
 		std::stringstream stream (text);
 		stream << std::hex << std::noshowbase;
@@ -383,15 +383,15 @@ bool rai::uint512_union::decode_hex (std::string const & text)
 			*this = number_l;
 			if (!stream.eof ())
 			{
-				result = true;
+				error = true;
 			}
 		}
 		catch (std::runtime_error &)
 		{
-			result = true;
+			error = true;
 		}
 	}
-	return result;
+	return error;
 }
 
 bool rai::uint512_union::operator!= (rai::uint512_union const & other_a) const
@@ -523,8 +523,8 @@ void rai::uint128_union::encode_hex (std::string & text) const
 
 bool rai::uint128_union::decode_hex (std::string const & text)
 {
-	auto result (text.size () > 32);
-	if (!result)
+	auto error (text.size () > 32);
+	if (!error)
 	{
 		std::stringstream stream (text);
 		stream << std::hex << std::noshowbase;
@@ -535,15 +535,15 @@ bool rai::uint128_union::decode_hex (std::string const & text)
 			*this = number_l;
 			if (!stream.eof ())
 			{
-				result = true;
+				error = true;
 			}
 		}
 		catch (std::runtime_error &)
 		{
-			result = true;
+			error = true;
 		}
 	}
-	return result;
+	return error;
 }
 
 void rai::uint128_union::encode_dec (std::string & text) const
@@ -557,8 +557,8 @@ void rai::uint128_union::encode_dec (std::string & text) const
 
 bool rai::uint128_union::decode_dec (std::string const & text)
 {
-	auto result (text.size () > 39 || (text.size () > 1 && text[0] == '0') || (text.size () > 0 && text[0] == '-'));
-	if (!result)
+	auto error (text.size () > 39 || (text.size () > 1 && text[0] == '0') || (text.size () > 0 && text[0] == '-'));
+	if (!error)
 	{
 		std::stringstream stream (text);
 		stream << std::dec << std::noshowbase;
@@ -569,15 +569,15 @@ bool rai::uint128_union::decode_dec (std::string const & text)
 			*this = number_l;
 			if (!stream.eof ())
 			{
-				result = true;
+				error = true;
 			}
 		}
 		catch (std::runtime_error &)
 		{
-			result = true;
+			error = true;
 		}
 	}
-	return result;
+	return error;
 }
 
 void format_frac (std::ostringstream & stream, rai::uint128_t value, rai::uint128_t scale, int precision)

--- a/rai/lib/work.cpp
+++ b/rai/lib/work.cpp
@@ -7,8 +7,7 @@
 
 bool rai::work_validate (rai::block_hash const & root_a, uint64_t work_a)
 {
-	auto result (rai::work_value (root_a, work_a) < rai::work_pool::publish_threshold);
-	return result;
+	return rai::work_value (root_a, work_a) < rai::work_pool::publish_threshold;
 }
 
 bool rai::work_validate (rai::block const & block_a)

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -584,7 +584,7 @@ void rai::logging::serialize_json (boost::property_tree::ptree & tree_a) const
 	tree_a.put ("work_generation_time", work_generation_time_value);
 	tree_a.put ("log_to_cerr", log_to_cerr_value);
 	tree_a.put ("max_size", max_size);
-	tree_a.put("rotation_size", rotation_size);
+	tree_a.put ("rotation_size", rotation_size);
 	tree_a.put ("flush", flush);
 }
 

--- a/rai/secure.cpp
+++ b/rai/secure.cpp
@@ -275,28 +275,28 @@ void rai::account_info::serialize (rai::stream & stream_a) const
 
 bool rai::account_info::deserialize (rai::stream & stream_a)
 {
-	auto result (read (stream_a, head.bytes));
-	if (!result)
+	auto error (read (stream_a, head.bytes));
+	if (!error)
 	{
-		result = read (stream_a, rep_block.bytes);
-		if (!result)
+		error = read (stream_a, rep_block.bytes);
+		if (!error)
 		{
-			result = read (stream_a, open_block.bytes);
-			if (!result)
+			error = read (stream_a, open_block.bytes);
+			if (!error)
 			{
-				result = read (stream_a, balance.bytes);
-				if (!result)
+				error = read (stream_a, balance.bytes);
+				if (!error)
 				{
-					result = read (stream_a, modified);
-					if (!result)
+					error = read (stream_a, modified);
+					if (!error)
 					{
-						result = read (stream_a, block_count);
+						error = read (stream_a, block_count);
 					}
 				}
 			}
 		}
 	}
-	return result;
+	return error;
 }
 
 bool rai::account_info::operator== (rai::account_info const & other_a) const
@@ -1028,30 +1028,30 @@ void rai::block_store::block_del (MDB_txn * transaction_a, rai::block_hash const
 
 bool rai::block_store::block_exists (MDB_txn * transaction_a, rai::block_hash const & hash_a)
 {
-	auto result (true);
+	auto exists (true);
 	rai::mdb_val junk;
 	auto status (mdb_get (transaction_a, send_blocks, rai::mdb_val (hash_a), junk));
 	assert (status == 0 || status == MDB_NOTFOUND);
-	result = status == 0;
-	if (!result)
+	exists = status == 0;
+	if (!exists)
 	{
 		auto status (mdb_get (transaction_a, receive_blocks, rai::mdb_val (hash_a), junk));
 		assert (status == 0 || status == MDB_NOTFOUND);
-		result = status == 0;
-		if (!result)
+		exists = status == 0;
+		if (!exists)
 		{
 			auto status (mdb_get (transaction_a, open_blocks, rai::mdb_val (hash_a), junk));
 			assert (status == 0 || status == MDB_NOTFOUND);
-			result = status == 0;
-			if (!result)
+			exists = status == 0;
+			if (!exists)
 			{
 				auto status (mdb_get (transaction_a, change_blocks, rai::mdb_val (hash_a), junk));
 				assert (status == 0 || status == MDB_NOTFOUND);
-				result = status == 0;
+				exists = status == 0;
 			}
 		}
 	}
-	return result;
+	return exists;
 }
 
 rai::block_counts rai::block_store::block_count (MDB_txn * transaction_a)
@@ -1272,12 +1272,12 @@ void rai::pending_key::serialize (rai::stream & stream_a) const
 
 bool rai::pending_key::deserialize (rai::stream & stream_a)
 {
-	auto result (rai::read (stream_a, account.bytes));
-	if (!result)
+	auto error (rai::read (stream_a, account.bytes));
+	if (!error)
 	{
-		result = rai::read (stream_a, hash.bytes);
+		error = rai::read (stream_a, hash.bytes);
 	}
-	return result;
+	return error;
 }
 
 bool rai::pending_key::operator== (rai::pending_key const & other_a) const
@@ -1376,12 +1376,12 @@ void rai::block_info::serialize (rai::stream & stream_a) const
 
 bool rai::block_info::deserialize (rai::stream & stream_a)
 {
-	auto result (rai::read (stream_a, account.bytes));
-	if (!result)
+	auto error (rai::read (stream_a, account.bytes));
+	if (!error)
 	{
-		result = rai::read (stream_a, balance.bytes);
+		error = rai::read (stream_a, balance.bytes);
 	}
-	return result;
+	return error;
 }
 
 bool rai::block_info::operator== (rai::block_info const & other_a) const

--- a/rai/versioning.cpp
+++ b/rai/versioning.cpp
@@ -33,20 +33,20 @@ void rai::account_info_v1::serialize (rai::stream & stream_a) const
 
 bool rai::account_info_v1::deserialize (rai::stream & stream_a)
 {
-	auto result (read (stream_a, head.bytes));
-	if (!result)
+	auto error (read (stream_a, head.bytes));
+	if (!error)
 	{
-		result = read (stream_a, rep_block.bytes);
-		if (!result)
+		error = read (stream_a, rep_block.bytes);
+		if (!error)
 		{
-			result = read (stream_a, balance.bytes);
-			if (!result)
+			error = read (stream_a, balance.bytes);
+			if (!error)
 			{
-				result = read (stream_a, modified);
+				error = read (stream_a, modified);
 			}
 		}
 	}
-	return result;
+	return error;
 }
 
 rai::mdb_val rai::account_info_v1::val () const
@@ -84,16 +84,16 @@ void rai::pending_info_v3::serialize (rai::stream & stream_a) const
 
 bool rai::pending_info_v3::deserialize (rai::stream & stream_a)
 {
-	auto result (rai::read (stream_a, source.bytes));
-	if (!result)
+	auto error (rai::read (stream_a, source.bytes));
+	if (!error)
 	{
-		result = rai::read (stream_a, amount.bytes);
-		if (!result)
+		error = rai::read (stream_a, amount.bytes);
+		if (!error)
 		{
-			result = rai::read (stream_a, destination.bytes);
+			error = rai::read (stream_a, destination.bytes);
 		}
 	}
-	return result;
+	return error;
 }
 
 bool rai::pending_info_v3::operator== (rai::pending_info_v3 const & other_a) const
@@ -142,24 +142,24 @@ void rai::account_info_v5::serialize (rai::stream & stream_a) const
 
 bool rai::account_info_v5::deserialize (rai::stream & stream_a)
 {
-	auto result (read (stream_a, head.bytes));
-	if (!result)
+	auto error (read (stream_a, head.bytes));
+	if (!error)
 	{
-		result = read (stream_a, rep_block.bytes);
-		if (!result)
+		error = read (stream_a, rep_block.bytes);
+		if (!error)
 		{
-			result = read (stream_a, open_block.bytes);
-			if (!result)
+			error = read (stream_a, open_block.bytes);
+			if (!error)
 			{
-				result = read (stream_a, balance.bytes);
-				if (!result)
+				error = read (stream_a, balance.bytes);
+				if (!error)
 				{
-					result = read (stream_a, modified);
+					error = read (stream_a, modified);
 				}
 			}
 		}
 	}
-	return result;
+	return error;
 }
 
 rai::mdb_val rai::account_info_v5::val () const


### PR DESCRIPTION
A very boring renaming patch. People seem to trip up on false-is-success, etc, so more descriptive names may help. @androm3da we talked about this one. I picked *error* instead of *failure*, since *error* is already used in quite a few places.

I'll do another round for the node subdir later on.