### PR TITLE
process_result::overspend -> process_result::negative_spend

### DIFF
--- a/rai/core_test/ledger.cpp
+++ b/rai/core_test/ledger.cpp
@@ -970,7 +970,7 @@ TEST (ledger, fail_send_bad_signature)
 	ASSERT_EQ (rai::process_result::bad_signature, result1.code);
 }
 
-TEST (ledger, fail_send_overspend)
+TEST (ledger, fail_send_negative_spend)
 {
 	bool init (false);
 	rai::block_store store (init, rai::unique_path ());
@@ -984,7 +984,7 @@ TEST (ledger, fail_send_overspend)
 	ASSERT_EQ (rai::process_result::progress, ledger.process (transaction, block1).code);
 	rai::keypair key2;
 	rai::send_block block2 (block1.hash (), key2.pub, 2, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0);
-	ASSERT_EQ (rai::process_result::overspend, ledger.process (transaction, block2).code);
+	ASSERT_EQ (rai::process_result::negative_spend, ledger.process (transaction, block2).code);
 }
 
 TEST (ledger, fail_send_fork)

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1285,11 +1285,11 @@ rai::process_return rai::block_processor::process_receive_one (MDB_txn * transac
 			}
 			break;
 		}
-		case rai::process_result::overspend:
+		case rai::process_result::negative_spend:
 		{
 			if (node.config.logging.ledger_logging ())
 			{
-				BOOST_LOG (node.log) << boost::str (boost::format ("Overspend for: %1%") % block_a->hash ().to_string ());
+				BOOST_LOG (node.log) << boost::str (boost::format ("Negative spend for: %1%") % block_a->hash ().to_string ());
 			}
 			break;
 		}

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -2412,8 +2412,9 @@ void rai::rpc_handler::process ()
 					error_response (response, "Bad signature");
 					break;
 				}
-				case rai::process_result::overspend:
+				case rai::process_result::negative_spend:
 				{
+					// TODO once we get RPC versioning, this should be changed to "negative spend"
 					error_response (response, "Overspend");
 					break;
 				}

--- a/rai/secure.cpp
+++ b/rai/secure.cpp
@@ -2407,7 +2407,7 @@ void ledger_processor::send_block (rai::send_block const & block_a)
 					auto latest_error (ledger.store.account_get (transaction, account, info));
 					assert (!latest_error);
 					assert (info.head == block_a.hashables.previous);
-					result.code = info.balance.number () >= block_a.hashables.balance.number () ? rai::process_result::progress : rai::process_result::overspend; // Is this trying to spend more than they have (Malicious)
+					result.code = info.balance.number () >= block_a.hashables.balance.number () ? rai::process_result::progress : rai::process_result::negative_spend; // Is this trying to spend a negative amount (Malicious)
 					if (result.code == rai::process_result::progress)
 					{
 						auto amount (info.balance.number () - block_a.hashables.balance.number ());

--- a/rai/secure.hpp
+++ b/rai/secure.hpp
@@ -312,7 +312,7 @@ enum class process_result
 	progress, // Hasn't been seen before, signed correctly
 	bad_signature, // Signature was bad, forged or transmission error
 	old, // Already seen and was valid
-	overspend, // Malicious attempt to overspend
+	negative_spend, // Malicious attempt to spend a negative amount
 	fork, // Malicious fork based on previous
 	unreceivable, // Source block doesn't exist or has already been received
 	gap_previous, // Block marked as previous is unknown


### PR DESCRIPTION
If a send block has a higher balance than the previous, then it's trying to spend a negative amount, not spend more than it has.