### PR TITLE
Stop processing blocks during shutdown

### DIFF
--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -462,7 +462,7 @@ public:
 	void process_blocks ();
 
 private:
-	bool stopped;
+	std::atomic<bool> stopped;
 	bool idle;
 	std::deque<rai::block_processor_item> blocks;
 	std::mutex mutex;


### PR DESCRIPTION
Exiting the wallet/node can sometimes take minutes. I believe the culprit is that `block_processor::process_receive_many` does not honor the stopped flag (and there can be a large amount of blocks queued up according to my debug dumps)

I've seen no hangs during shutdown so far with this patch. 

Any problems with exiting the process_receive_many loops?

I made be stopped flag atomic, because the function is called without mutex protection from the election::confirm_once path.