### PR TITLE
Fix ledger_processor::change_block block_put

### DIFF
--- a/rai/secure.cpp
+++ b/rai/secure.cpp
@@ -2662,7 +2662,7 @@ void ledger_processor::change_block (rai::change_block const & block_a)
 				{
 					assert (!hash2.is_zero ());
 					ledger.store.hash2_put (transaction, hash, hash2);
-					ledger.store.block_put (transaction, hash2, block_a);
+					ledger.store.block_put (transaction, hash, block_a);
 					auto balance (ledger.balance (transaction, block_a.hashables.previous));
 					ledger.store.representation_add (transaction, hash, balance);
 					ledger.store.representation_add (transaction, info.rep_block, 0 - balance);


### PR DESCRIPTION
Now it matches the other block types. I think this might have also been part of #598, as I got a different segfault after running it for a while.